### PR TITLE
fix(coreos-init): Disable physical/vm specific units in containers.

### DIFF
--- a/systemd/dev-disk-by\x2dlabel-OEM.device
+++ b/systemd/dev-disk-by\x2dlabel-OEM.device
@@ -1,0 +1,2 @@
+[Unit]
+ConditionVirtualization=!container

--- a/systemd/dev-disk-by\x2dlabel-STATE.device
+++ b/systemd/dev-disk-by\x2dlabel-STATE.device
@@ -1,0 +1,2 @@
+[Unit]
+ConditionVirtualization=!container

--- a/systemd/dev-mode.service
+++ b/systemd/dev-mode.service
@@ -4,6 +4,7 @@ DefaultDependencies=no
 Requires=mnt-stateful_partition.mount
 After=mnt-stateful_partition.mount
 Before=local-fs.target
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/mnt-stateful_partition.mount
+++ b/systemd/mnt-stateful_partition.mount
@@ -7,6 +7,7 @@ After=resize-stateful_partition.service
 Conflicts=umount.target
 Before=umount.target
 Before=local-fs.target
+ConditionVirtualization=!container
 
 [Mount]
 What=/dev/disk/by-label/STATE

--- a/systemd/resize-stateful_partition.service
+++ b/systemd/resize-stateful_partition.service
@@ -7,6 +7,7 @@ Requires=dev-disk-by\x2dlabel-STATE.device
 After=dev-disk-by\x2dlabel-STATE.device
 Wants=local-fs-pre.target
 Before=local-fs-pre.target
+ConditionVirtualization=!container
 
 [Service]
 Type=oneshot

--- a/systemd/update-engine.service
+++ b/systemd/update-engine.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Update Engine
+ConditionVirtualization=!container
 
 [Service]
 Type=dbus

--- a/systemd/usr-share-oem.mount
+++ b/systemd/usr-share-oem.mount
@@ -5,6 +5,7 @@ Wants=local-fs-pre.target
 Conflicts=umount.target
 Before=umount.target
 Before=local-fs.target
+ConditionVirtualization=!container
 
 [Mount]
 What=/dev/disk/by-label/OEM


### PR DESCRIPTION
When booting a CoreOS filesystem with a container such as systemd-nspawn
there isn't a STATE and OEM partition to mount. All units that cannot or
should not run in this situation are given a "not container" condition
and simply become no-op steps in the boot process. The container is
expected to provide /mnt/stateful_partition since CoreOS still needs it
but cannot mount it itself. Booting looks something like this:

systemd-nspawn --boot --read-only -D ./rootfs \
    --bind ./state:/mnt/stateful_partition
