### PR TITLE
fix(systemd/usr-share-oem): remove mount restrictions on OEM

### DIFF
--- a/systemd/usr-share-oem.mount
+++ b/systemd/usr-share-oem.mount
@@ -10,6 +10,6 @@ ConditionVirtualization=!container
 [Mount]
 What=/dev/disk/by-label/OEM
 Where=/usr/share/oem
-Options=nodev,noexec,nosuid,commit=600,ro
+Options=nodev,commit=600
 Type=ext4
 FsckPassNo=0


### PR DESCRIPTION
the OEM partition has restrictions that were carried over from ChromeOS.
Remove these restrictions.
