### PR TITLE
tmpfiles.conf: systemd wants containers in /var/lib/container

### DIFF
--- a/configs/tmpfiles.conf
+++ b/configs/tmpfiles.conf
@@ -2,7 +2,7 @@
 d /home/core            0755    core    core    -       -
 
 # var locations not covered by other ebuilds
-d /var/lib/containers   -       -       -       -       -
+d /var/lib/container    -       -       -       -       -
 d /var/lib/ureadahead   -       -       -       -       -
 d /var/log/metrics      0755    core    core    -       -
 


### PR DESCRIPTION
Stop recreating the /var/lib/containers/ directory, no one uses it, systemd wants /var/lib/container/ instead.
