### PR TITLE
feat(systemd): mount kernel cmdline options

### DIFF
--- a/systemd/system/dev-disk-by\x2dlabel-OEM.device
+++ b/systemd/system/dev-disk-by\x2dlabel-OEM.device
@@ -1,3 +1,4 @@
 [Unit]
-ConditionKernelCommandLine=!diskless
+ConditionKernelCommandLine=!coreos.diskless
+ConditionKernelCommandLine=!coreos.statediskonly
 ConditionVirtualization=!container

--- a/systemd/system/dev-disk-by\x2dlabel-STATE.device
+++ b/systemd/system/dev-disk-by\x2dlabel-STATE.device
@@ -1,3 +1,3 @@
 [Unit]
-ConditionKernelCommandLine=!diskless
+ConditionKernelCommandLine=!coreos.diskless
 ConditionVirtualization=!container

--- a/systemd/system/media-state.mount
+++ b/systemd/system/media-state.mount
@@ -4,6 +4,7 @@ Wants=resize-state.service
 After=resize-state.service
 Conflicts=umount.target
 Before=local-fs.target umount.target
+ConditionKernelCommandLine=!coreos.diskless
 ConditionVirtualization=!container
 
 [Mount]

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -4,6 +4,8 @@ Wants=addon-run@usr-share-oem.service addon-config@usr-share-oem.service
 Before=addon-run@usr-share-oem.service addon-config@usr-share-oem.service
 Conflicts=umount.target
 Before=local-fs.target umount.target
+ConditionKernelCommandLine=!coreos.statediskonly
+ConditionKernelCommandLine=!coreos.diskless
 ConditionVirtualization=!container
 
 [Mount]


### PR DESCRIPTION
coreos.diskless will avoid mounting any disks
coreos.statediskonly will only mount the stateful disk
