### PR TITLE
feat(pxe-update-engine): simple update engine for PXE

### DIFF
--- a/scripts/pxe_update_engine
+++ b/scripts/pxe_update_engine
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) 2013 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# This is a simple check-in update_engine for PXE. Since the real update_engine
+# can't run on rootless machines run this instead for now. This will be replaced
+# by a new Go application that does kexec in place.
+
+set -e -o pipefail
+
+source /etc/lsb-release
+
+BOOT_ID=$(</proc/sys/kernel/random/boot_id)
+
+VERSION="${COREOS_RELEASE_VERSION:-testing}"
+TRACK="${COREOS_RELEASE_VERSION:-testing-channel}"
+AUSERVER="${COREOS_AUSERVER:-https://api.core-os.net/v1/update/}"
+
+BODY="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<request protocol=\"3.0\" version=\"CoreOSUpdateEngine-0.1.0.0\" updaterversion=\"CoreOSUpdateEngine-0.1.0.0\" installsource=\"scheduler\" ismachine=\"1\">
+<os version=\"Chateau\" platform=\"CoreOS\" sp=\"${VERSION}\"></os>
+<app appid=\"{e96281a6-d1af-4bde-9a0a-97b76e56dc57}\" oem=\"pxe\" version=\"${VERSION}\" track=\"${TRACK}\" bootid=\"{${BOOT_ID}}\" lang=\"en-US\" board=\"amd64-generic\" hardware_class=\"\" delta_okay=\"false\" >
+<event eventtype=\"3\" eventresult=\"2\" previousversion=\"\"></event>
+</app>
+</request>"
+
+echo Request: "${BODY}"
+
+curl -H "text/xml" --capath /usr/share/coreos-ca-certificates -X POST -d "${BODY}" "${AUSERVER}"

--- a/systemd/system/pxe-update-engine.service
+++ b/systemd/system/pxe-update-engine.service
@@ -1,0 +1,3 @@
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/coreos/pxe_update_engine

--- a/systemd/system/pxe-update-engine.timer
+++ b/systemd/system/pxe-update-engine.timer
@@ -1,0 +1,12 @@
+[Unit]
+ConditionKernelCommandLine=|root=squashfs:
+ConditionKernelCommandLine=|root=squashfs
+ConditionVirtualization=!container
+
+[Timer]
+OnBootSec=7minutes
+OnActiveSec=41minutes
+Unit=pxe-update-engine.service
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
the full update engine doesn't work under PXE. Ping so we get a sense of
the load once we enable PXE updates.
