### PR TITLE
fix(resize_state): Force sector alignment to 1.

### DIFF
--- a/scripts/resize_state
+++ b/scripts/resize_state
@@ -45,6 +45,7 @@ if sgdisk -v "$DISK_DEVNAME" | grep -q "^Problem: The secondary header"; then
     if ! sgdisk \
         --move-second-header \
         --delete="$partno" \
+        --set-alignment=1 \
         --new="$partno:$STATE_ID_PART_ENTRY_OFFSET:0" \
         --typecode="$partno:$STATE_ID_PART_ENTRY_TYPE" \
         --partition-guid="$partno:$STATE_ID_PART_ENTRY_UUID" \


### PR DESCRIPTION
gdisk will set the minimum alignment to 8 sectors (4 KB) on all drives
larger than 300 GB just in case it is a newer drive with 4KB physical
sectors. In our case this is terrible because we aren't properly aligned
right now so when resizing for large disks sgdisk shifts the start of
the partition and then everything breaks and puppies cry.
