### PR TITLE
run partprobe after writing coreos to local disk

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -200,6 +200,9 @@ done
 echo "Writing ${IMAGE_NAME} to ${DEVICE}..."
 bunzip2 --show-progress --stdout "${WORKDIR}/${IMAGE_NAME}" >"${DEVICE}"
 
+# inform the OS of partition table changes
+/usr/sbin/partprobe
+
 rm -rf "${WORKDIR}"
 trap - EXIT
 


### PR DESCRIPTION
I recently pxe booted CoreOS and ran coreos-install to install it on local disk. The docs mention mounting /dev/sda9 after the OS image is written, but it didn't exist. Realized 'partprobe' must be run for the OS to see new partitions.
