### PR TITLE
Cleanup of coreos-install script

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -144,7 +144,7 @@ if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|loop)$ ]]; then
 fi
 
 if [[ ! -w "${DEVICE}" ]]; then
-    echo "$0: Target block device (${DEVICE}) is not writable." >&2
+    echo "$0: Target block device (${DEVICE}) is not writable (are you root?)" >&2
     exit 1
 fi
 
@@ -198,10 +198,10 @@ for sum in sha1 sha512; do
 done
 
 echo "Writing ${IMAGE_NAME} to ${DEVICE}..."
-bunzip2 --show-progress --stdout "${WORKDIR}/${IMAGE_NAME}" >"${DEVICE}"
+bunzip2 -v --stdout "${WORKDIR}/${IMAGE_NAME}" >"${DEVICE}"
 
 # inform the OS of partition table changes
-/usr/sbin/partprobe
+partprobe
 
 rm -rf "${WORKDIR}"
 trap - EXIT


### PR DESCRIPTION
Removed bunzip2 --show-progress because this flag is not present on
Ubuntu, Debian, MacPorts, or Centos. As far as I can tell, this flag was
only added in 1.0.6.1 by the MinGW maintainers. This is replaced with
bunzip2 -v.

Changed the fully pathed partprobe to use a nonpathed partprobe because
partprobe lives in /sbin on EL 6.

Changed the message given when the block device is not writable to
remind the user to assume root privileges.
