### PR TITLE
feat(etcd-discovery): Add support for etcd discovery URLs

### DIFF
--- a/bin/coreos-c10n
+++ b/bin/coreos-c10n
@@ -51,7 +51,7 @@ trap "rm -f ${TMP}" EXIT
 echo "${USER_DATA}" > $TMP
 
 # If user-data is a script, execute it
-if echo "${USER_DATA}" | head -n 1 | grep -q '^#!'; then
+if  head -n 1 $TMP | grep -q '^#!'; then
 	echo "Executing user-data as script"
 	chmod +x $TMP
 	$TMP


### PR DESCRIPTION
A user can submit a she-banged script in their EC2 user-data that will be executed by coreos-c10n. If a line in that script starts with 'ETCD_DISCOVERY_URL=', the contents of that variable will be used to bootstrap the local etcd service instead of the dying c10n service.
