### PR TITLE
fix(coreos-c10n): Revert restart policy in c10n

### DIFF
--- a/systemd/system/coreos-c10n.service
+++ b/systemd/system/coreos-c10n.service
@@ -5,8 +5,6 @@ Description=CoreOS Coordination
 Type=oneshot
 RemainAfterExit=no
 ExecStart=/usr/bin/coreos-c10n
-Restart=on-failure
-RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restart is not valid for oneshot services. Oops...
