### PR TITLE
fix(coreos-install): fix coreos-install URLs

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -154,7 +154,8 @@ if [ -n "${OEM}" ]; then
   FLAVOR="${OEM}_"
 fi
 
-IMAGE_URL="http://storage.core-os.net/coreos/amd64-generic/${VERSION}/coreos_production_${FLAVOR}image.bin.bz2"
+BASE_URL="http://storage.core-os.net/coreos/amd64-generic/${VERSION}/coreos_production_${FLAVOR}image.bin"
+IMAGE_URL="${BASE_URL}.bz2"
 DIGESTS_URL="${IMAGE_URL}.DIGESTS.asc"
 IMAGE_NAME="${IMAGE_URL##*/}"
 DIGESTS_NAME="${DIGESTS_URL##*/}"


### PR DESCRIPTION
deedubs in #coreos reported a problem with coreos-install:

```
./coreos-install -d /dev/disk/by-label/DOROOT grep: /etc/lsb-release: No such
file or directory Downloading and verifying coreos_production_image.bin.bz2... 
gpg: Signature made Tue 14 Jan 2014 07:23:12 AM UTC using RSA key ID 74E7E361 
gpg: key 93D2DCB4 marked as ultimately trusted gpg: checking the trustdb gpg:
3 marginal(s) needed, 1 complete(s) needed, PGP trust model gpg: depth: 0 
valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u gpg: Good signature
from "CoreOS Buildbot (Offical Builds) <buildbot@coreos.com>"
 % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                Dload  Upload   Total   Spent    Left  Speed 
100  164M  100  164M    0     0  3790k      0  0:00:44  0:00:44 --:--:-- 4910k 
coreos_production_image.bin.bz2: FAILED sha1sum: WARNING: 1 computed checksum
did NOT match
```

I tried to reproduce and got a different bug:

```
$ sudo coreos-install -d /dev/sda
/usr/bin/coreos-install: Image signature unavailable: 
http://storage.core-os.net/coreos/amd64-generic/231.0.0/coreos_production_image.bin.bz2.DIGESTS.asc
```

I believe what happened was there is an old digest file that deedubs 
downloaded from our mirror. In the case of the 231.0.0 build this old digest
file isn't there so I got a 404 instead.
