### PR TITLE
Follow redirect on user data URL download

### DIFF
--- a/bin/coreos-c10n
+++ b/bin/coreos-c10n
@@ -41,7 +41,7 @@ if echo "${USER_DATA}" | grep -q '^https://'; then
 
 	echo "Downloading contents of URL: ${USER_DATA}"
 
-	USER_DATA="$(curl -s $USER_DATA)"
+	USER_DATA="$(curl -L -s $USER_DATA)"
 fi
 
 # Create temporary file that gets cleaned up on exit


### PR DESCRIPTION
Recently gist.github.com started redirecting to gist.githubusercontent.com
for raw downloads.  While you can just put the gist.githubusercontent.com
URL in the user data it would be nice in general to follow redirects for
the download.
