### PR TITLE
add(resize_btrfs): Add temporary script to resize btrfs on boot.

### DIFF
--- a/scripts/resize_btrfs
+++ b/scripts/resize_btrfs
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Temporary btrfs resize support until it is written in C and moved to the
+# cgpt resize command. I'm waiting to do that until after we can drop resize
+# support for ext[234] since the two are different enough that supporting both
+# in the same code is more awkward than I want to deal with in C.
+
+set -e -o pipefail
+
+COREOS_RESIZE="3884dd41-8582-4404-b9a8-e9b84f2df50e"
+
+declare -a DEV_LIST
+lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT | mapfile DEV_LIST
+
+for dev_info in "${DEV_LIST[@]}"; do
+    eval "$dev_info"
+    if [[ "${PARTTYPE}" != "${COREOS_RESIZE}" || "${FSTYPE}" != "btrfs" ||
+          -z "${NAME}" || -z "${MOUNTPOINT}" ]]; then
+        continue
+    fi
+
+    device="/dev/${NAME}"
+    old_size=$(blockdev --getsz "${device}")
+    cgpt resize "${device}"
+
+    # Only resize filesystem if the partition changed
+    if [[ "${old_size}" -eq $(blockdev --getsz "${device}") ]]; then
+        continue
+    fi
+
+    # map the device name to the btrfs device id
+    device_id=$(btrfs filesystem show "${MOUNTPOINT}" | \
+                awk "/${MOUNTPOINT}\$/ {print \$2}")
+    btrfs filesystem resize "${device_id}:max" "${MOUNTPOINT}"
+done

--- a/systemd/system/resize-btrfs.service
+++ b/systemd/system/resize-btrfs.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Resize Btrfs Filesystems
+ConditionVirtualization=!container
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/lib/coreos/resize_btrfs
+StandardOutput=journal+console


### PR DESCRIPTION
Eventually this functionality will be moved into the `cgpt resize`
command but since the best way to handle btrfs is very different from
ext4 I don't want to support both in the cgpt code at the same time.
