### PR TITLE
fix(resize_btrfs): Fix my bogus shell script.

### DIFF
--- a/scripts/resize_btrfs
+++ b/scripts/resize_btrfs
@@ -9,7 +9,7 @@ set -e -o pipefail
 COREOS_RESIZE="3884dd41-8582-4404-b9a8-e9b84f2df50e"
 
 declare -a DEV_LIST
-lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT | mapfile DEV_LIST
+mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT)
 
 for dev_info in "${DEV_LIST[@]}"; do
     eval "$dev_info"
@@ -29,6 +29,6 @@ for dev_info in "${DEV_LIST[@]}"; do
 
     # map the device name to the btrfs device id
     device_id=$(btrfs filesystem show "${MOUNTPOINT}" | \
-                awk "/${MOUNTPOINT}\$/ {print \$2}")
+                awk -v "d=${device}" -e 'd == $8 {print $2}')
     btrfs filesystem resize "${device_id}:max" "${MOUNTPOINT}"
 done


### PR DESCRIPTION
- mapfile cannot be used in a pipe since a pipeline runs in a subshell.
  Use bash command substitution instead to feed mapfile data.
- Fix obviously bogus awk command for parsing btrfs output.
