### PR TITLE
fix(systemd/network): obey DHCP's MTU

### DIFF
--- a/systemd/network/99-default.network
+++ b/systemd/network/99-default.network
@@ -1,2 +1,5 @@
 [Network]
 DHCP=true
+
+[DHCPv4]
+UseMTU=true


### PR DESCRIPTION
We have to obey the MTU since some networks and providers will want to set it
to 1460, etc.
