### PR TITLE
fix "Unknown lvalue 'FsckPassNo' in section 'Mount'"

### DIFF
--- a/systemd/system/media-state.mount
+++ b/systemd/system/media-state.mount
@@ -15,4 +15,3 @@ What=/dev/disk/by-label/STATE
 Where=/media/state
 Options=commit=600,data=ordered
 Type=ext4
-FsckPassNo=0

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -13,4 +13,3 @@ What=/dev/disk/by-label/OEM
 Where=/usr/share/oem
 Options=nodev,commit=600
 Type=ext4
-FsckPassNo=0


### PR DESCRIPTION
FsckPassNo in no longer supported in systemd 
