### PR TITLE
fix(coreos-install): LVM is a third valid lsblk for coreos-install -d

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -138,7 +138,7 @@ if [[ -z "${DEVICE}" ]]; then
     exit 1
 fi
 
-if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|loop)$ ]]; then
+if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|loop|lvm)$ ]]; then
     echo "$0: Target block device (${DEVICE}) is not a full disk." >&2
     exit 1
 fi


### PR DESCRIPTION
Note: You may need to manually use kpartx -d to remove device-mapper
devices after you mount partition 9 and insert your ssh authorized_keys.
