### PR TITLE
fix(issuegen): Assorted fixes, most importantly ignore veth interfaces.

### DIFF
--- a/configs-usr/tmpfiles.d/issuegen.conf
+++ b/configs-usr/tmpfiles.d/issuegen.conf
@@ -1,0 +1,1 @@
+L   /etc/issue  -   -   -   -   ../run/issue

--- a/scripts/issuegen
+++ b/scripts/issuegen
@@ -11,9 +11,14 @@ print_issue() {
     echo
 }
 
-mkdir -p /run/issue.d
-for eth in "$@"; do
-    echo "${eth}: \\4{${eth}} \\6{${eth}}" > "/run/issue.d/${eth}"
-done
+case "$1" in
+    add)
+        mkdir -p /run/issue.d
+        echo "${2}: \\4{${2}} \\6{${2}}" > "/run/issue.d/${2}"
+        ;;
+    remove)
+        rm -f "/run/issue.d/${2}"
+        ;;
+esac
 
 print_issue > /run/issue

--- a/udev/rules.d/90-issuegen.rules
+++ b/udev/rules.d/90-issuegen.rules
@@ -1,2 +1,2 @@
-ACTION!="remove", SUBSYSTEM=="net", NAME=="", RUN+="/usr/lib/coreos/issuegen $kernel"
-ACTION!="remove", SUBSYSTEM=="net", NAME!="", RUN+="/usr/lib/coreos/issuegen $name"
+ACTION=="add", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/coreos/issuegen add $env{INTERFACE}"
+ACTION=="remove", SUBSYSTEM=="net", ENV{INTERFACE}=="e*", RUN+="/usr/lib/coreos/issuegen remove $env{INTERFACE}"


### PR DESCRIPTION
- Only match interface names that start with e, these are usually
  ethernet. We use the same rule for enabling DHCP in networkd.
- Support removing interfaces!
- Add tmpfiles rule so issuegen works on usr PXE images.
