### PR TITLE
fix(usr-share-oem): Don't auto-mount OEM on PXE/ISO/etc systems.

### DIFF
--- a/systemd/system/dev-disk-by\x2dlabel-OEM.device
+++ b/systemd/system/dev-disk-by\x2dlabel-OEM.device
@@ -2,3 +2,4 @@
 ConditionKernelCommandLine=!root=squashfs:
 ConditionKernelCommandLine=!root=squashfs
 ConditionVirtualization=!container
+ConditionPathExists=!/usr/.noupdate

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -7,6 +7,7 @@ Before=local-fs.target umount.target
 ConditionKernelCommandLine=!root=squashfs:
 ConditionKernelCommandLine=!root=squashfs
 ConditionVirtualization=!container
+ConditionPathExists=!/usr/.noupdate
 
 [Mount]
 What=/dev/disk/by-label/OEM


### PR DESCRIPTION
The /usr/.noupdate flag is set on systems that don't use our standard
GPT partition layout to block update_engine. On such systems we also
need to block the auto-mounting of OEM since it likely does not exist.

The name 'noupdate' in this context is odd but works for now. I'll
consider changing the logic or flag name when I gut out the old STATE
partition logic.
