### PR TITLE
fix(resize_btrfs): Search by device name instead of mount point.

### DIFF
--- a/scripts/resize_btrfs
+++ b/scripts/resize_btrfs
@@ -28,7 +28,7 @@ for dev_info in "${DEV_LIST[@]}"; do
     fi
 
     # map the device name to the btrfs device id
-    device_id=$(btrfs filesystem show "${MOUNTPOINT}" | \
+    device_id=$(btrfs filesystem show -d "${device}" | \
                 awk -v "d=${device}" -e 'd == $8 {print $2}')
     btrfs filesystem resize "${device_id}:max" "${MOUNTPOINT}"
 done


### PR DESCRIPTION
It seems the `rootfs / rootfs rw 0 0` entry in the mount table is
confusing to `btrfs fi show`, causing it to exit with code 1 despite
there actually being a btrfs filesystem mounted to / later in the table.

Or at least that's what my initial reading of the code implies. In
either case using -d option to prevent it from scanning mount points
works around the bug.

Fixes https://github.com/coreos/bugs/issues/3
