### PR TITLE
fix(coreos-setup-environment): Add RemainAfterExit=yes

### DIFF
--- a/systemd/system/coreos-setup-environment.service
+++ b/systemd/system/coreos-setup-environment.service
@@ -7,6 +7,7 @@ ConditionPathIsMountPoint=/usr
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/coreos-setup-environment /etc/environment
 
 [Install]


### PR DESCRIPTION
There is no reason for this to get re-executed if a service depending on
it comes up some time after boot. This is usually the case with Vagrant.

Noted in: https://github.com/coreos/coreos-overlay/pull/568
