### PR TITLE
fix(coreos-install): Don't abort after filtering partprobe errors.

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -199,7 +199,8 @@ bunzip2 -v --stdout "${WORKDIR}/${IMAGE_NAME}" >"${DEVICE}"
 # this will *always* generate warnings, so make them go away.
 partprobe "${DEVICE}" 2>&1 | grep -v \
     -e "^Error: The backup GPT table is not at the end of the disk" \
-    -e "^Warning: Not all of the space available"
+    -e "^Warning: Not all of the space available" \
+    || true # It is perfectly OK for grep to exit with non-zero here.
 
 if [[ -n "${CLOUDINIT}" ]]; then
     # The ROOT partition should be #9 but make no assumptions here!


### PR DESCRIPTION
Filtering out pointless errors from partprobe in efe90ac7 broke this
script, causing it to abort when there weren't any errors other than
what it filtered. Oops.

Reported in https://github.com/coreos/init/commit/efe90ac77f970e257e2313a05f1dd0e8ba9cd84e#commitcomment-6202472
