### PR TITLE
fix(scripts/motdgen): use a timer instead of polling dbus

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Copyright (c) 2014 The CoreOS Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
@@ -8,31 +8,16 @@
 [ -e /usr/share/coreos/update.conf ] && source /usr/share/coreos/update.conf
 [ -e /etc/coreos/update.conf ] && source /etc/coreos/update.conf
 
-gen() {
-	mkdir -p /run/coreos
-	echo -e "Core\033[38;5;45mO\033[38;5;206mS\033[39m (${GROUP})" > /run/coreos/motd
+mkdir -p /run/coreos
+echo -e "Core\033[38;5;45mO\033[38;5;206mS\033[39m (${GROUP})" > /run/coreos/motd
 
-	systemctl is-active locksmithd > /dev/null
-	if [ $? -ne 0 ]; then
-		echo -e "Update Strategy: \033[31mNo Reboots\033[39m" >> /run/coreos/motd
-	fi
+if systemctl is-active locksmithd > /dev/null; then
+	echo -e "Update Strategy: \033[31mNo Reboots\033[39m" >> /run/coreos/motd
+fi
 
-	systemctl list-units --state=failed --no-legend > /run/coreos/motd-failed
-	count=$(cat /run/coreos/motd-failed | wc -l)
-	if [ ${count} -ne 0 ]; then
-		echo -e "Failed Units: \033[31m${count}\033[39m" >> /run/coreos/motd
-		cat /run/coreos/motd-failed | awk '{ print "  " $1 }' >> /run/coreos/motd
-	fi
-}
-
-gen
-
-dbus-send --system --dest=org.freedesktop.systemd1.Manager \
-	/org/freedesktop/systemd1 \
-	org.freedesktop.systemd1.Manager.Subscribe
-
-filter="type='signal',interface='org.freedesktop.DBus.Properties',member='PropertiesChanged'"
-dbus-monitor --system ${filter} |
-while read -r line; do
-	echo ${line} | egrep 'variant string "(failed|active)"' > /dev/null && gen
-done
+systemctl list-units --state=failed --no-legend > /run/coreos/motd-failed
+count=$(cat /run/coreos/motd-failed | wc -l)
+if [ ${count} -ne 0 ]; then
+	echo -e "Failed Units: \033[31m${count}\033[39m" >> /run/coreos/motd
+	cat /run/coreos/motd-failed | awk '{ print "  " $1 }' >> /run/coreos/motd
+fi

--- a/systemd/system/motdgen.service
+++ b/systemd/system/motdgen.service
@@ -3,4 +3,5 @@ Description=Generate /run/coreos/motd
 Before=systemd-user-sessions.service
 
 [Service]
+Type=oneshot
 ExecStart=/usr/lib/coreos/motdgen

--- a/systemd/system/motdgen.timer
+++ b/systemd/system/motdgen.timer
@@ -1,0 +1,5 @@
+[Unit]
+Description=Generate /run/coreos/motd
+
+[Timer]
+OnUnitActiveSec=60


### PR DESCRIPTION
motdgen can take a ridiculous amount of CPU when you have lots of units. I
talked with David Strauss and he wants similar functionality and is working
with upstream to make it cheap to do. Until then run this on a timer.
