### PR TITLE
coreos-install script fails with ubuntu 14.04

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -205,7 +205,7 @@ partprobe "${DEVICE}" 2>&1 | grep -v \
 if [[ -n "${CLOUDINIT}" ]]; then
     # The ROOT partition should be #9 but make no assumptions here!
     # Also don't mount by label directly in case other devices conflict.
-    ROOT_DEV=$(lsblk -rp -o name,partlabel "${DEVICE}"  | \
+    ROOT_DEV=$(lsblk -rP -o name,label "${DEVICE}"  | \
                awk '$2 == "ROOT" {print $1; exit}')
 
     if [[ -z "${ROOT_DEV}" ]]; then
@@ -215,7 +215,7 @@ if [[ -n "${CLOUDINIT}" ]]; then
 
     echo "Installing cloud-config..."
     mkdir -p "${WORKDIR}/rootfs"
-    mount -t btrfs -o subvol=root "${ROOT_DEV}" "${WORKDIR}/rootfs"
+    mount -t btrfs -o subvol=root "/dev/${ROOT_DEV}" "${WORKDIR}/rootfs"
     trap "umount '${WORKDIR}/rootfs' && rm -rf '${WORKDIR}'" EXIT
 
     mkdir -p "${WORKDIR}/rootfs/var/lib/coreos-install"


### PR DESCRIPTION
I had to hack the coreos-install script to get it to work from Ubuntu 14.04 Destop LiveCD.

For lsbk on line 208 I had to use the uppercase argument `P` instead of `p` and change from `partlabel` to `label`. Both those options were reported as unknown in the terminal. 

Because of the `partlabel` change, I also had to change from ${ROOT_DEV} to /dev/${ROOT_DEV} on line 211.

Not saying this is the correct way to resolve this issue (might break for other distros). But it should be clear where the errors were for me when executing the script. Hope it helps.
