### PR TITLE
setup-environment needs to run after network.target

### DIFF
--- a/systemd/system/coreos-setup-environment.service
+++ b/systemd/system/coreos-setup-environment.service
@@ -4,6 +4,8 @@ Description=Modifies /etc/environment for CoreOS
 RequiresMountsFor=/usr/share/oem
 # we only want this to work on usr images
 ConditionPathIsMountPoint=/usr
+Wants=network.target
+After=network.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
I get this with the current alpha, installed to disk on bare metal:

```
core@core0001 ~ $ cat /etc/environment
COREOS_PUBLIC_IPV4=0.0.0.0
COREOS_PRIVATE_IPV4=127.0.0.1
```

```
-- Reboot --
May 20 20:32:31 core0001 systemd[1]: Starting Modifies /etc/environment for CoreOS...
May 20 20:32:31 core0001 coreos-setup-environment[3290]: RTNETLINK answers: Network is unreachable
May 20 20:32:31 core0001 systemd[1]: Started Modifies /etc/environment for CoreOS.
```

I believe adding network.target as a prereq here will cause it to stop failing.
