### PR TITLE
fix(coreos-install): Add channel to final status message.

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -227,4 +227,4 @@ fi
 rm -rf "${WORKDIR}"
 trap - EXIT
 
-echo "Success! CoreOS ${VERSION_ID}${OEM_ID:+ (${OEM_ID})} is installed on ${DEVICE}"
+echo "Success! CoreOS ${CHANNEL_ID} ${VERSION_ID}${OEM_ID:+ (${OEM_ID})} is installed on ${DEVICE}"


### PR DESCRIPTION
Noted in https://github.com/coreos/init/pull/100#issuecomment-43796760
