### PR TITLE
fix(systemd): add OnBootSec=0 for motdgen.timer

### DIFF
--- a/systemd/system/motdgen.timer
+++ b/systemd/system/motdgen.timer
@@ -3,3 +3,4 @@ Description=Generate /run/coreos/motd
 
 [Timer]
 OnUnitActiveSec=60
+OnBootSec=0


### PR DESCRIPTION
This is required to first activate the timer. Otherwise it never runs.

Sorry @marineam
