### PR TITLE
fix(coreos-install): Fix compatibility with older versions.

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -163,6 +163,12 @@ else
     IMAGE_NAME="coreos_production_image.bin.bz2"
 fi
 
+# for compatibility with old versions that didn't support channels
+if [[ "${VERSION_ID}" =~ ^(alpha|beta|stable)$ ]]; then
+    CHANNEL_ID="${VERSION_ID}"
+    VERSION_ID="current"
+fi
+
 BASE_URL="http://${CHANNEL_ID}.release.core-os.net/amd64-usr/${VERSION_ID}"
 IMAGE_URL="${BASE_URL}/${IMAGE_NAME}"
 SIG_NAME="${IMAGE_NAME}.sig"


### PR DESCRIPTION
When adding proper support for selecting release channels I forgot to
add the special case to make `-V alpha` continue to work.

Fixes https://github.com/coreos/bugs/issues/29
