### PR TITLE
feature(network-online.target): ensure IP routable before enabling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,15 @@ install:
 		$(DESTDIR)/usr/lib/systemd/system \
 		$(DESTDIR)/usr/lib/systemd/network \
 		$(DESTDIR)/usr/lib/systemd/system-generators \
+		$(DESTDIR)/usr/lib/systemd/system/network-online.target.wants \
 		$(DESTDIR)/usr/lib/tmpfiles.d \
 		$(DESTDIR)/etc/env.d \
 		$(DESTDIR)/usr/share/ssh
 	install -m 755 bin/* $(DESTDIR)/usr/bin
 	install -m 755 scripts/* $(DESTDIR)/usr/lib/coreos
 	install -m 644 systemd/system/* $(DESTDIR)/usr/lib/systemd/system
+	ln -sf ../wait-for-network.service \
+		$(DESTDIR)/usr/lib/systemd/system/network-online.target.wants
 	install -m 644 systemd/network/* $(DESTDIR)/usr/lib/systemd/network
 	install -m 755 systemd/system-generators/* \
 		$(DESTDIR)/usr/lib/systemd/system-generators

--- a/scripts/wait_for_network
+++ b/scripts/wait_for_network
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+routable_ip () { ip route get 8.8.8.8 2>/dev/null | awk '{print $7}'; }
+interval=0.1 # seconds
+timeout=300000 # 5 minutes in milliseconds (must be multiple of interval)
+
+msecs=0
+while [ -z $(routable_ip) ] ; do
+	echo "interface not up after $msecs ms..."
+	sleep $interval
+	msecs=$((msecs+100))
+	if [ "$msecs" == "$timeout" ] ; then
+		echo "Gave up waiting for routable IP."
+		exit 1
+	fi
+done
+echo "Got routable IP $(routable_ip) after $msecs ms."
+exit 0

--- a/systemd/system/coreos-setup-environment.service
+++ b/systemd/system/coreos-setup-environment.service
@@ -4,6 +4,8 @@ Description=Modifies /etc/environment for CoreOS
 RequiresMountsFor=/usr/share/oem
 # we only want this to work on usr images
 ConditionPathIsMountPoint=/usr
+Wants=network-online.target
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/systemd/system/wait-for-network.service
+++ b/systemd/system/wait-for-network.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Wait for Network
+Wants=network.target
+Before=network.target network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/coreos/wait_for_network
+
+[Install]
+WantedBy=network-online.target
+


### PR DESCRIPTION
This implements `network-online.target` by waiting until there is a route to `8.8.8.8` (arbitrarily-chosen public IP). It changes `coreos-setup-environment.service` to run after `network-online.target`.

Where previously my environment's public IP would be `0.0.0.0`:

```
core@localhost ~ $ cat /etc/environment
COREOS_PUBLIC_IPV4=10.0.2.15
COREOS_PRIVATE_IPV4=127.0.0.1
```

![img](https://d2oawfjgoy88bd.cloudfront.net/533da756c38aa51217f640dd/533da777c38aa51219a9875c/537e937cc38aa547518df544.png?Expires=1400890623&Signature=RF1KeVFH0oO5l6nq28OG1z5MjsZioZY1mz6QhLlrRAngfnsqZsoc~KekkgPWgi-JW71oF~E~p89NSaLHSJ3aGrNwVqTh1qa8faav3bHSwubT6wHJFncsIh~2p72~7i5agnxlvBA40AA3Q59bkzj~QqMJz50RpMMznHeABhEVvRwpRQHiDdXxCCDHm7R2w18ywbGcWc1B4nAHSEO5VzFcMS79CoYTrI6V9uCmpSEEC5~UVj3wWaMWMWGXplXYI1WR59NxvS7yOADduX9VUtpY9qfJOZT7EvbU3Vi8K5Vi8JWWAmTTOuDLxtNxzBsPSxWS9Y7UstVYQQgtlmrTiO3Tyw__&Key-Pair-Id=APKAJHEJJBIZWFB73RSA)

```
 -- Logs begin at Fri 2014-05-23 00:11:18 UTC, end at Fri 2014-05-23 00:14:08 UTC . --
May 23 00:11:33 localhost systemd[1]: Starting Wait for Network...
May 23 00:11:33 localhost wait_for_network[2998]: interface not up after 0 ms...
May 23 00:11:33 localhost wait_for_network[2998]: interface not up after 100 ms...
May 23 00:11:33 localhost wait_for_network[2998]: interface not up after 200 ms...
May 23 00:11:33 localhost wait_for_network[2998]: Got routable IP 10.0.2.15 after 300 ms.
May 23 00:11:33 localhost systemd[1]: Started Wait for Network.
```

Other services that should also be waiting on this that spring to mind:
- Whatever fetches remote cloudinit files.
