### PR TITLE
feat(udev): Add short disk by-id dev links for GCE

### DIFF
--- a/udev/rules.d/90-cloud-storage.rules
+++ b/udev/rules.d/90-cloud-storage.rules
@@ -1,0 +1,12 @@
+# Rules to make easy to predict/remember device names on cloud providers.
+
+ACTION=="remove", GOTO="cloud_storage_end"
+SUBSYSTEM!="block", GOTO="cloud_storage_end"
+
+# Google GCE by-id
+KERNEL=="sd*|vd*", ENV{ID_VENDOR}=="Google", ENV{ID_MODEL}=="PersistentDisk", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
+KERNEL=="sd*|vd*", ENV{ID_VENDOR}=="Google", ENV{ID_MODEL}=="PersistentDisk", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
+
+# TODO: Anyone else support friendly names?
+
+LABEL="cloud_storage_end"


### PR DESCRIPTION
Standard GCE images setup `/dev/disk/by-id/google-<disk-name>` links for
attached storage. The default rules only provide the much-more verbose
`/dev/disk/by-id/scsi-0Google_PersistentDisk_<disk-name>`.

Fixes https://github.com/coreos/bugs/issues/13
