### PR TITLE
fix(sshd_keygen): Generate all key types

### DIFF
--- a/scripts/sshd_keygen
+++ b/scripts/sshd_keygen
@@ -7,22 +7,11 @@
 SSH_DIR=/etc/ssh
 mkdir -p ${SSH_DIR}
 
-if ! sshd -t &> /dev/null ; then
-  # sshd will not start with current config, generate a new set of keys.
-  for KEY_TYPE in rsa dsa ; do
-    KEY_FILE=${SSH_DIR}/ssh_host_${KEY_TYPE}_key
-    # If keys exist delete them because they are not valid and ssh-keygen
-    # will not overwrite them.
-    rm -f ${KEY_FILE} ${KEY_FILE}.pub
-    ssh-keygen -q -f ${KEY_FILE} -N '' -t ${KEY_TYPE} ||
-      echo "Failed to generate ssh key."
-  done
-fi
+ssh-keygen -A || echo "Failed to generate ssh keys."
 
 # Provide key fingerprints via issue
 mkdir -p /run/issue.d
-for KEY_TYPE in rsa dsa ; do
-  KEY_FILE=${SSH_DIR}/ssh_host_${KEY_TYPE}_key
+for KEY_FILE in $(ls ${SSH_DIR}/ssh_host_*_key) ; do
   ssh-keygen -l -f ${KEY_FILE}
 done | awk '{print "SSH host key: " $2 " " $4}' > /run/issue.d/00_ssh_host_keys
 /usr/lib/coreos/issuegen


### PR DESCRIPTION
Set sshd_keygen to generate all key types instead of just RSA and DSA. This behavior is now the same as sshd.service.
