### PR TITLE
udev: preserve old network device name with newer systemd versions.

### DIFF
--- a/udev/rules.d/79-net-google-compat.rules
+++ b/udev/rules.d/79-net-google-compat.rules
@@ -1,0 +1,13 @@
+# Newer udev versions removed support for persistent names for virtio devices.
+# To preserve compatibility with existing GCE OEM code fill in the old name.
+
+ACTION!="add", GOTO="net_google_compat_end"
+SUBSYSTEM!="net", GOTO="net_google_compat_end"
+DEVPATH!="/devices/pci0000:00/0000:00:04.0/virtio1/net/*", GOTO="net_google_compat_end"
+ATTR{dmi/id/sys_vendor}!="Google", GOTO="net_google_compat_end"
+
+ENV{ID_NET_NAME}="ens4v1"
+ENV{ID_NET_NAME_PATH}="enp0s4v1"
+ENV{ID_NET_NAME_SLOT}="ens4v1"
+
+LABEL="net_google_compat_end"


### PR DESCRIPTION
Required to maintain compatibility with existing GCE installs.
