### PR TITLE
udev: properly skip GCE compatibility rule on other systems

### DIFF
--- a/udev/rules.d/79-net-google-compat.rules
+++ b/udev/rules.d/79-net-google-compat.rules
@@ -4,7 +4,7 @@
 ACTION!="add", GOTO="net_google_compat_end"
 SUBSYSTEM!="net", GOTO="net_google_compat_end"
 DEVPATH!="/devices/pci0000:00/0000:00:04.0/virtio1/net/*", GOTO="net_google_compat_end"
-ATTR{dmi/id/sys_vendor}!="Google", GOTO="net_google_compat_end"
+ATTR{[dmi/id]sys_vendor}!="Google", GOTO="net_google_compat_end"
 
 ENV{ID_NET_NAME}="ens4v1"
 ENV{ID_NET_NAME_PATH}="enp0s4v1"


### PR DESCRIPTION
Matching GCE instances based on DMI info isn't working properly, a
slightly different syntax is required to match attributes outside of the
current device's tree. I had seen this syntax in use but didn't know
what it meant because it isn't documented. For reference it means:

```
"[<SUBSYSTEM>/<KERNEL>]<attribute>"
```

This slipped through testing because when udev was unable to find the
requested attribute it simply skipped that line rather than interpreting
the value as blank as I had assumed it would. So the rules appeared to
work on GCE and I usually don't run QEMU instances with more than one
network interface.
