### PR TITLE
Allow override for BASE_URL

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -169,7 +169,7 @@ if [[ "${VERSION_ID}" =~ ^(alpha|beta|stable)$ ]]; then
     VERSION_ID="current"
 fi
 
-BASE_URL="http://${CHANNEL_ID}.release.core-os.net/amd64-usr/${VERSION_ID}"
+BASE_URL=${BASE_URL:-"http://${CHANNEL_ID}.release.core-os.net/amd64-usr/${VERSION_ID}"}
 IMAGE_URL="${BASE_URL}/${IMAGE_NAME}"
 SIG_NAME="${IMAGE_NAME}.sig"
 SIG_URL="${BASE_URL}/${SIG_NAME}"


### PR DESCRIPTION
Using this method the BASE_URL of an image can be overridden at
runtime allowing for users to specify their own CDN mirror.
