### PR TITLE
check for wget and gpg before proceeding

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -5,6 +5,10 @@
 
 set -e -o pipefail
 
+# Ensure that required executables exist before proceeding
+which wget >/dev/null || exit 1
+which gpg >/dev/null || exit 1
+
 # Everything we do should be user-access only!
 umask 077
 


### PR DESCRIPTION
wget and gpg are not necessarily present (such as a livecd image), but the script proceeds anyway and leaves things in an inconsistent state, causing confusing errors if it's re-run.  This bails out early if the dependencies are not present.
