### PR TITLE
Added --inet4-only to wget calls in coreos-install script.

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -212,12 +212,12 @@ IMAGE_URL="${BASE_URL}/${IMAGE_NAME}"
 SIG_NAME="${IMAGE_NAME}.sig"
 SIG_URL="${BASE_URL}/${SIG_NAME}"
 
-if ! wget --spider --quiet "${IMAGE_URL}"; then
+if ! wget --inet4-only --spider --quiet "${IMAGE_URL}"; then
     echo "$0: Image URL unavailable: $IMAGE_URL" >&2
     exit 1
 fi
 
-if ! wget --spider --quiet "${SIG_URL}"; then
+if ! wget --inet4-only --spider --quiet "${SIG_URL}"; then
     echo "$0: Image signature unavailable: $SIG_URL" >&2
     exit 1
 fi
@@ -232,11 +232,11 @@ mkdir "${GNUPGHOME}"
 gpg --batch --quiet --import <<<"$GPG_KEY"
 
 echo "Downloading the signature for ${IMAGE_URL}..."
-wget --no-verbose -O "${WORKDIR}/${SIG_NAME}" "${SIG_URL}"
+wget --inet4-only --no-verbose -O "${WORKDIR}/${SIG_NAME}" "${SIG_URL}"
 
 echo "Downloading, writing and verifying ${IMAGE_NAME}..."
 declare -a EEND
-if ! wget --no-verbose -O - "${IMAGE_URL}" \
+if ! wget --inet4-only --no-verbose -O - "${IMAGE_URL}" \
     | tee >(bunzip2 --stdout >"${DEVICE}") \
     | gpg --batch --trusted-key "${GPG_LONG_ID}" \
         --verify "${WORKDIR}/${SIG_NAME}" -


### PR DESCRIPTION
My server is configured for ipv6 and when I wget the image url I get the following:

```
~ # wget http://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2
--2014-09-23 10:15:12--  http://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2
Resolving stable.release.core-os.net (stable.release.core-os.net)... 2a00:1450:4010:c02::80, 74.125.205.128
Connecting to stable.release.core-os.net (stable.release.core-os.net)|2a00:1450:4010:c02::80|:80... connected.
HTTP request sent, awaiting response... 403 Forbidden
2014-09-23 10:15:13 ERROR 403: Forbidden.
```

Adding --inet4-only to all wget calls fixes this issue.
