### PR TITLE
Change issuegen to use #!/bin/bash due to bash-style echo usage

### DIFF
--- a/scripts/issuegen
+++ b/scripts/issuegen
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
The \'s are always interpreted in dash/POSIX shell, issuegen expects
them to be ignored without -e.
