### PR TITLE
Show CoreOS version in motd

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -8,8 +8,10 @@
 [ -e /usr/share/coreos/update.conf ] && source /usr/share/coreos/update.conf
 [ -e /etc/coreos/update.conf ] && source /etc/coreos/update.conf
 
+source /usr/lib/os-release
+
 mkdir -p /run/coreos
-echo -e "Core\033[38;5;206mO\033[38;5;45mS\033[39m (${GROUP})" > /run/coreos/motd
+echo -e "Core\033[38;5;206mO\033[38;5;45mS\033[39m ${GROUP} (${VERSION})" > /run/coreos/motd
 
 if ! systemctl is-active locksmithd > /dev/null; then
 	echo -e "Update Strategy: \033[31mNo Reboots\033[39m" >> /run/coreos/motd


### PR DESCRIPTION
Add CoreOS version to `motd` by parsing the `VERSION` line from `/etc/os-release`.

Reasoning: I find myself quite often in the situation that I would like to quickly check which version a node is running. This requires me to ssh into a node and `cat /etc/*release`. This change makes it more convenient by showing the version in the motd.
