### PR TITLE
network: use DHCP domain names

### DIFF
--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -6,4 +6,5 @@ DHCP=v4
 
 [DHCP]
 UseMTU=true
+UseDomains=true
 RequestBroadcast=true

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,5 +1,6 @@
 [Network]
 DHCP=v4
 
-[DHCPv4]
+[DHCP]
 UseMTU=true
+UseDomains=true


### PR DESCRIPTION
Our patched version of v215 fixed support for DHCP domain names
differently than what eventually landed upstream. In current systemd
version using DHCP provided domain names is disabled by default and must
be explicitly enabled while our patched v215 and older versions prior to
the introduction of systemd-resovled used domain information by default.

Fixes https://github.com/coreos/bugs/issues/220
