### PR TITLE
issuegen: remove DNS domain name from issue

### DIFF
--- a/scripts/issuegen
+++ b/scripts/issuegen
@@ -4,7 +4,7 @@ set -e
 
 print_issue() {
     echo
-    echo 'This is \n.\O (\s \m \r) \t'
+    echo 'This is \n (\s \m \r) \t'
     for note in /run/issue.d/*; do
         [ -f "${note}" ] && cat "${note}"
     done


### PR DESCRIPTION
Avoids DNS lookup which may hang for a few seconds, avoids misleading
unknown_domain, avoids bogus output when the hostname is actually set to
the fully qualified domain name.