### PR TITLE
Shut down password ssh access for root

### DIFF
--- a/configs/sshd_config
+++ b/configs/sshd_config
@@ -3,3 +3,5 @@ UsePrivilegeSeparation sandbox
 Subsystem sftp internal-sftp
 ClientAliveInterval 180
 UseDNS no
+PasswordAuthentication no
+PermitRootLogin no


### PR DESCRIPTION
Currently it seems that the only protection against ssh root logins is that no password is set. If a user unintentionally sets a root password, assuming that you can't login as root, they inadvertently open themselves up to a dictionary attack.

This can be overridden by a competent user, but if the intent is no root logins, it should be set explicitly, not just by dint of not having a password. 