### PR TITLE
issuegen: add explicit dependency on sshd-keygen.service

### DIFF
--- a/systemd/system/issuegen.service
+++ b/systemd/system/issuegen.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Generate /run/issue
 Before=systemd-user-sessions.service
+After=sshd-keygen.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
if issuegen doesn't wait for sshd-keygen to complete, issuegen will
sometimes display empty ssh host keys.

fixes coreos/bugs#106