### PR TITLE
Set up an automounter for /boot

### DIFF
--- a/systemd/system/boot.automount
+++ b/systemd/system/boot.automount
@@ -1,0 +1,10 @@
+[Unit]
+Description=Boot partition Automount Point
+DefaultDependencies=no
+Before=sysinit.target
+ConditionVirtualization=!container
+ConditionPathExists=!/usr/.noupdate
+
+[Automount]
+Where=/boot
+

--- a/systemd/system/boot.mount
+++ b/systemd/system/boot.mount
@@ -1,0 +1,10 @@
+[Unit]
+Description=Boot partition
+DefaultDependencies=no
+ConditionVirtualization=!container
+ConditionPathExists=!/usr/.noupdate
+
+[Mount]
+What=/dev/disk/by-label/EFI-SYSTEM
+Where=/boot
+

--- a/systemd/system/local-fs.target.wants/boot.automount
+++ b/systemd/system/local-fs.target.wants/boot.automount
@@ -1,0 +1,1 @@
+../boot.automount


### PR DESCRIPTION
We need to mount the EFI system partition for updates so we can drop the
new kernel into it.