### PR TITLE
logrotate: add config and systemd units for logrotate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install:
 		$(DESTDIR)/usr/lib/systemd/system-generators
 	install -m 644 udev/rules.d/* $(DESTDIR)/lib/udev/rules.d
 	install -m 644 configs/editor.sh $(DESTDIR)/etc/env.d/99editor
+	install -m 644 configs/logrotate.conf $(DESTDIR)/usr/share/logrotate/
 	install -m 600 configs/sshd_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/ssh_config $(DESTDIR)/usr/share/ssh/
 	install -m 644 configs/tmpfiles.d/* $(DESTDIR)/usr/lib/tmpfiles.d/

--- a/configs/logrotate.conf
+++ b/configs/logrotate.conf
@@ -1,0 +1,26 @@
+# keep only the most recent old log.
+rotate 1
+
+# create new (empty) log files after rotating old ones.
+create
+
+# use date as a suffix of the rotated file.
+dateext
+
+# compress rotated log files.
+compress
+
+missingok
+notifempty
+nomail
+noolddir
+
+# must match creation rules in /usr/lib/tmpfiles.d/var.conf
+/var/log/wtmp {
+    create 0664 root utmp
+    size 1M
+}
+/var/log/btmp {
+    create 0600 root utmp
+    size 1M
+}

--- a/systemd/system/logrotate.service
+++ b/systemd/system/logrotate.service
@@ -1,0 +1,5 @@
+[Unit]
+Description=Rotate and Compress System Logs
+
+[Service]
+ExecStart=/usr/sbin/logrotate /usr/share/logrotate/logrotate.conf

--- a/systemd/system/logrotate.timer
+++ b/systemd/system/logrotate.timer
@@ -1,0 +1,7 @@
+[Unit]
+Description=Daily Log Rotation
+
+[Timer]
+OnCalendar=daily
+AccuracySec=1h
+Persistent=true

--- a/systemd/system/multi-user.target.wants/logrotate.timer
+++ b/systemd/system/multi-user.target.wants/logrotate.timer
@@ -1,0 +1,1 @@
+../logrotate.timer


### PR DESCRIPTION
The only two system logs that should need rotation by default are btmp
and wtmp, everything else is in the journal. btmp in particular is
likely to become huge due to the oodles of ssh brute-force bots.