### PR TITLE
coreos-autologin-generator: set TMPDIR to /run

### DIFF
--- a/systemd/system-generators/coreos-autologin-generator
+++ b/systemd/system-generators/coreos-autologin-generator
@@ -12,6 +12,9 @@ fi
 
 # Use the first path provided, the "Normal" target for generators.
 if [[ $# -gt 0 ]]; then
+    TMPDIR="/run" # bash creates temp files in $TMPDIR for heredocs, but /tmp
+                  # isn't a tmpfs yet when system-generators are run, so reuse
+                  # /run.  Otherwise we'll fail if / is in a read-only state.
     DEST="$1"
 fi
 


### PR DESCRIPTION
If your system has somehow managed to wind up with / mounted read-only
when booting, coreos.autologin will fail because /tmp isn't yet a tmpfs,
and the bash script uses heredoc which creates temp files.