### PR TITLE
remove some useless use of cat (alt)

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -22,8 +22,7 @@ if ! systemctl is-active locksmithd > /dev/null; then
 fi
 
 systemctl list-units --state=failed --no-legend > /run/coreos/motd-failed
-count=$(cat /run/coreos/motd-failed | wc -l)
-if [ ${count} -ne 0 ]; then
+if [[ -s /run/coreos/motd-failed ]]; then
 	echo -e "Failed Units: \033[31m${count}\033[39m" >> /run/coreos/motd
 	awk '{ print "  " $1 }' /run/coreos/motd-failed >> /run/coreos/motd
 fi

--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -25,5 +25,5 @@ systemctl list-units --state=failed --no-legend > /run/coreos/motd-failed
 count=$(cat /run/coreos/motd-failed | wc -l)
 if [ ${count} -ne 0 ]; then
 	echo -e "Failed Units: \033[31m${count}\033[39m" >> /run/coreos/motd
-	cat /run/coreos/motd-failed | awk '{ print "  " $1 }' >> /run/coreos/motd
+	awk '{ print "  " $1 }' /run/coreos/motd-failed >> /run/coreos/motd
 fi


### PR DESCRIPTION
as #182, but avoids the `wc -l` entirely, because the read builtin by itself is sufficient to determine whether the file is nonempty.