### PR TITLE
motdgen: simplify motdgen and remove timer unit

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -16,13 +16,3 @@ echo -e "Core\033[38;5;206mO\033[38;5;45mS\033[39m ${GROUP} (${VERSION})" > /run
 if [[ -d "/etc/motd.d" ]]; then
 	cat /etc/motd.d/*.conf 2>/dev/null >> /run/coreos/motd || true
 fi
-
-if ! systemctl is-active locksmithd > /dev/null; then
-	echo -e "Update Strategy: \033[31mNo Reboots\033[39m" >> /run/coreos/motd
-fi
-
-systemctl list-units --state=failed --no-legend > /run/coreos/motd-failed
-if [[ -s /run/coreos/motd-failed ]]; then
-	echo -e "Failed Units: \033[31m${count}\033[39m" >> /run/coreos/motd
-	awk '{ print "  " $1 }' /run/coreos/motd-failed >> /run/coreos/motd
-fi

--- a/systemd/system/motdgen.timer
+++ b/systemd/system/motdgen.timer
@@ -1,6 +1,0 @@
-[Unit]
-Description=Generate /run/coreos/motd
-
-[Timer]
-OnUnitActiveSec=60
-OnBootSec=0

--- a/systemd/system/multi-user.target.wants/motdgen.timer
+++ b/systemd/system/multi-user.target.wants/motdgen.timer
@@ -1,1 +1,0 @@
-../motdgen.timer


### PR DESCRIPTION
This removes the systemctl invocations from motdgen and their associated
output.  Maintaining these were what necessitated the motdgen.timer
unit, and we'll instead move this into the core user's login session
startup scripts.

Fixes https://github.com/coreos/bugs/issues/47