### PR TITLE
extend-filesystems script: fix raid device name when using HP Smart Array CCISS driver

### DIFF
--- a/scripts/extend-filesystems
+++ b/scripts/extend-filesystems
@@ -15,7 +15,7 @@ set -e -o pipefail
 COREOS_RESIZE="3884dd41-8582-4404-b9a8-e9b84f2df50e"
 
 declare -a DEV_LIST
-mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT)
+mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT | sed -e 's/cciss!/cciss\//')
 
 for dev_info in "${DEV_LIST[@]}"; do
     eval "$dev_info"

--- a/scripts/extend-filesystems
+++ b/scripts/extend-filesystems
@@ -15,10 +15,11 @@ set -e -o pipefail
 COREOS_RESIZE="3884dd41-8582-4404-b9a8-e9b84f2df50e"
 
 declare -a DEV_LIST
-mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT | sed -e 's/cciss!/cciss\//')
+mapfile DEV_LIST < <(lsblk -P -o NAME,PARTTYPE,FSTYPE,MOUNTPOINT)
 
 for dev_info in "${DEV_LIST[@]}"; do
     eval "$dev_info"
+    NAME=${NAME//\!//}
     if [[ "${PARTTYPE}" != "${COREOS_RESIZE}" ]] || \
        [[ -z "${NAME}" ]] || \
        [[ -z "${MOUNTPOINT}" ]] || \


### PR DESCRIPTION
Hi,

this should fix coreos/bugs#1037.
It's kind of a "hotfix" so if there's a proper way of fixing this let me know.

Thanks!