### PR TITLE
network: disable new persistent style names for virtio devices

### DIFF
--- a/systemd/network/98-virtio.link
+++ b/systemd/network/98-virtio.link
@@ -1,0 +1,6 @@
+# systemd has re-enabled the persistent device naming scheme for virtio.
+# Migration will come later but for now preserve the old behavior by the
+# "slot" and "path" name policies.
+[Match]
+NamePolicy=kernel database onboard
+MACAddressPolicy=persistent

--- a/udev/rules.d/79-net-google-compat.rules
+++ b/udev/rules.d/79-net-google-compat.rules
@@ -7,7 +7,5 @@ DEVPATH!="/devices/pci0000:00/0000:00:04.0/virtio1/net/*", GOTO="net_google_comp
 ATTR{[dmi/id]sys_vendor}!="Google", GOTO="net_google_compat_end"
 
 ENV{ID_NET_NAME}="ens4v1"
-ENV{ID_NET_NAME_PATH}="enp0s4v1"
-ENV{ID_NET_NAME_SLOT}="ens4v1"
 
 LABEL="net_google_compat_end"


### PR DESCRIPTION
In order to decouple the upgrade of systemd from the tricky migration of
network device names this new rule preserves the previous behavior.

Fixes https://github.com/coreos/bugs/issues/1168

TODO: need to build and test on GCE which has it's own mess