### PR TITLE
systemd: remove restart policy from sshd-keygen

### DIFF
--- a/systemd/system/sshd-keygen.service
+++ b/systemd/system/sshd-keygen.service
@@ -5,5 +5,4 @@ Before=sshd.service
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-Restart=on-failure
 ExecStart=/usr/lib/coreos/sshd_keygen


### PR DESCRIPTION
It is not valid to have a restart policy for one shots. We probably
don't want this to retry anyway - we'd rather figure out why it's
failing in the first place.