### PR TITLE
network: set ClientIdentifier=mac for the PXE OEM

### DIFF
--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -1,0 +1,10 @@
+[Match]
+KernelCommandLine=!coreos.oem.id
+
+[Network]
+DHCP=yes
+
+[DHCP]
+ClientIdentifier=mac
+UseMTU=true
+UseDomains=true


### PR DESCRIPTION
This fixes coreos/bugs#1432.  I've booted CoreOS with coreos.oem=pxe while dumping the network traffic, and the DHCP client identifier is the MAC address.