### PR TITLE
test: fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
 python:
   - "2.7"
-install: pip install -r tests/requirements.txt --use-mirrors
+install: pip install -r tests/requirements.txt
 script: trial tests


### PR DESCRIPTION
Looks like this flag was removed:

    The command "pip install -r tests/requirements.txt --use-mirrors"
    failed and exited with 2