### PR TITLE
systemd: use syslog by default for mdmonitor.service

### DIFF
--- a/systemd/system/mdmonitor.service.d/00-syslog.conf
+++ b/systemd/system/mdmonitor.service.d/00-syslog.conf
@@ -1,0 +1,3 @@
+[Service]
+Environment="MDADM_MONITOR_ARGS=--scan --syslog"
+


### PR DESCRIPTION
fixes #1548