### PR TITLE
Resolve symlink for device

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -309,6 +309,11 @@ if [[ -z "${DEVICE}" ]]; then
     exit 1
 fi
 
+# Symlink may cause trouble with lsblk and blkid
+if [[ -L "${DEVICE}" ]]; then
+    DEVICE=$(readlink -f "${DEVICE}")
+fi
+
 if ! [[ $(lsblk -n -d -o TYPE "${DEVICE}") =~ ^(disk|loop|lvm)$ ]]; then
     echo "$0: Target block device (${DEVICE}) is not a full disk." >&2
     exit 1


### PR DESCRIPTION
Resolving the symlink before using the Device Variable fixes issues with lsblk and blkid. Symlinks may be problematic when using ZFS and using a path like /dev/zvol/poolname/volname. Fixes coreos/bugs#1599 for me.