### PR TITLE
check if coreos release file exists before getting BOARD

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -26,7 +26,9 @@ fi
 : ${VERSION_ID:=current}
 CHANNEL_ID=${GROUP:-stable}
 
-BOARD=$(gawk --field-separator '=' '/COREOS_RELEASE_BOARD=/ { print $2 }' /usr/share/coreos/release)
+if [[ -e /usr/share/coreos/release ]]; then
+    BOARD=$(gawk --field-separator '=' '/COREOS_RELEASE_BOARD=/ { print $2 }' /usr/share/coreos/release)
+fi
 
 BOARD=${BOARD:-"amd64-usr"}
 


### PR DESCRIPTION
Commit 563ea0488b96eccab257c2287566c50f51e547fa (PR #228) introduced a problem on systems where no `/usr/share/coreos/release` file is present as the script aborts with a gawk *cannot open file* error.

```bash
root@rescue:~# ./coreos-install -d /dev/sda -C stable -c ./cloud-config.yaml
gawk: fatal: cannot open file `/usr/share/coreos/release' for reading (No such file or directory)
```

This fix introduces a simple check for file presence before feeding it to gawk. If the gawk step is skipped a default value (`amd64-usr`) will be assigned to `BOARD` anyway.
