### PR TITLE
rainbow in motd

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -11,7 +11,7 @@
 source /usr/lib/os-release
 
 mkdir -p /run/coreos
-echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} (${VERSION})" > /run/coreos/motd
+echo -e "\e[${ANSI_COLOR}mContainer Linux by Core\033[38;5;206mO\033[38;5;45mS\033[39m ${GROUP} (${VERSION})" > /run/coreos/motd
 
 if [[ -d "/etc/motd.d" ]]; then
 	cat /etc/motd.d/*.conf 2>/dev/null >> /run/coreos/motd || true


### PR DESCRIPTION
Feel free to turn this down right away as I obviously don't know branding strategy etc, etc. 
I just enjoyed the rainbow.

Previously when logging into an instance it would have almost a rainbow around
the word "CoreOS", the O and S were different colors. This adds that back after
the name change.

This was removed in https://github.com/coreos/init/commit/d43bba6378339a1e15f7a3ac824364959f34a5f3
with the changing of the name.

![2017-01-15-11-45-19_3199x872](https://cloud.githubusercontent.com/assets/1445228/21965640/e6a83398-db18-11e6-8ebb-5d3189d6a32d.png)

