### PR TITLE
Revert "feat(motdgen): Ensure that motdgen runs after locksmith starts"

### DIFF
--- a/systemd/system/motdgen.service
+++ b/systemd/system/motdgen.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Generate /run/coreos/motd
 Before=systemd-user-sessions.service
-After=locksmithd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This reverts commit 5dcf1ab5e84204df5a5281f9e229ee379280d8f5.

This has the potential to cause a deadlock since this unit wedges itself
between locksmith starting and the user sessions starting. Since the
reboot strategy isn't even shown in the MOTD anymore (it's in the
profile), just drop this ordering.