### PR TITLE
coreos-install: If -C is specified without -V, assume "-V current"

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -42,9 +42,9 @@ done
 
 USAGE="Usage: $0 [-V version] [-d /dev/device]
 Options:
-    -d DEVICE   Install CoreOS to the given device.
+    -d DEVICE   Install Container Linux to the given device.
     -V VERSION  Version to install (e.g. current) [default: ${VERSION_ID}]
-    -B BOARD    CoreOS board to use [default: ${BOARD}]
+    -B BOARD    Container Linux board to use [default: ${BOARD}]
     -C CHANNEL  Release channel to use (e.g. beta) [default: ${CHANNEL_ID}]
     -o OEM      OEM type to install (e.g. ami) [default: ${OEM_ID:-(none)}]
     -c CLOUD    Insert a cloud-init config to be executed on boot.
@@ -55,8 +55,8 @@ Options:
     -n          Copy generated network units to the root partition.
     -h          This ;-)
 
-This tool installs CoreOS on a block device. If you PXE booted CoreOS on a
-machine then use this tool to make a permanent install.
+This tool installs CoreOS Container Linux on a block device. If you PXE booted
+Container Linux on a machine then use this tool to make a permanent install.
 "
 
 # Image signing key:
@@ -377,7 +377,7 @@ if [[ "${VERSION_ID}" == "current" ]]; then
         echo "$0: version.txt unavailable: ${VERSIONTXT_URL}" >&2
         exit 1
     fi
-    echo "Current version of CoreOS ${CHANNEL_ID} is ${VERSION_ID}"
+    echo "Current version of CoreOS Container Linux ${CHANNEL_ID} is ${VERSION_ID}"
 fi
 
 IMAGE_URL="${BASE_URL}/${VERSION_ID}/${IMAGE_NAME}"
@@ -483,4 +483,4 @@ fi
 rm -rf "${WORKDIR}"
 trap - EXIT
 
-echo "Success! CoreOS ${CHANNEL_ID} ${VERSION_ID}${OEM_ID:+ (${OEM_ID})} is installed on ${DEVICE}"
+echo "Success! CoreOS Container Linux ${CHANNEL_ID} ${VERSION_ID}${OEM_ID:+ (${OEM_ID})} is installed on ${DEVICE}"

--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -297,9 +297,9 @@ CLOUDINIT=""
 while getopts "V:B:C:d:o:c:i:t:b:nvh" OPTION
 do
     case $OPTION in
-        V) VERSION_ID="$OPTARG" ;;
+        V) VERSION_ID="$OPTARG"; VERSION_SPECIFIED=1 ;;
         B) BOARD="$OPTARG" ;;
-        C) CHANNEL_ID="$OPTARG" ;;
+        C) CHANNEL_ID="$OPTARG"; CHANNEL_SPECIFIED=1 ;;
         d) DEVICE="$OPTARG" ;;
         o) OEM_ID="$OPTARG" ;;
         c) CLOUDINIT="$OPTARG" ;;
@@ -312,6 +312,10 @@ do
         *) exit 1;;
     esac
 done
+
+if [[ -n "${CHANNEL_SPECIFIED}" && -z "${VERSION_SPECIFIED}" ]]; then
+    VERSION_ID="current"
+fi
 
 # Device is required, must not be a partition, must be writable
 if [[ -z "${DEVICE}" ]]; then


### PR DESCRIPTION
Since May 2014 our installation documentation has claimed that `coreos-install -C <channel>` is the way to install the latest version in `<channel>`. However, ever since the -C option was first implemented, -C has not overridden a defaulted -V. Thus the documented command only ever worked in the following cases:

1. coreos-install was run on a non-CoreOS host (so we didn't inherit a version from `os-release`).

2. The host was on the desired channel (so -C was redundant and the defaulted version existed in that channel). We would succeed but not necessarily install the latest version.

3. The host was on a different channel, but the host's version was also available in the desired channel due to bit-for-bit promotion. Again we wouldn't necessarily get the latest version.

Otherwise it failed on a 404.

In many cases we were probably lucky and users PXE- or ISO-booted an image that matched the channel they wished to install, but the documentation does not require this.

Since we no longer ever promote releases without bumping their version, overriding -C but defaulting -V does not make sense. If we see this combination, assume `-V current`.

Also update output for Container Linux rename.