### PR TITLE
coreos-install: Make -t option a no-op

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -49,7 +49,6 @@ Options:
     -o OEM      OEM type to install (e.g. ami) [default: ${OEM_ID:-(none)}]
     -c CLOUD    Insert a cloud-init config to be executed on boot.
     -i IGNITION Insert an Ignition config to be executed on boot.
-    -t TMPDIR   Temporary location with enough space to download images.
     -v          Super verbose, for debugging.
     -b BASEURL  URL to the image mirror (overrides BOARD)
     -n          Copy generated network units to the root partition.
@@ -328,7 +327,7 @@ do
         o) OEM_ID="$OPTARG" ;;
         c) CLOUDINIT="$OPTARG" ;;
         i) IGNITION="$OPTARG" ;;
-        t) export TMPDIR="$OPTARG" ;;
+        t) ;; # compatibility option; previously set TMPDIR
         v) set -x ;;
         b) BASE_URL="${OPTARG%/}" ;;
         n) COPY_NET=1;;


### PR DESCRIPTION
It previously set TMPDIR, but we no longer put anything large in there.  Drop the option for simplicity, but continue to respect TMPDIR just in case.