### PR TITLE
Allow running scripts when building MOTD

### DIFF
--- a/scripts/motdgen
+++ b/scripts/motdgen
@@ -13,6 +13,12 @@ source /usr/lib/os-release
 mkdir -p /run/coreos
 echo -e "\e[${ANSI_COLOR}m${NAME}\e[39m ${GROUP} (${VERSION})" > /run/coreos/motd
 
-if [[ -d "/etc/motd.d" ]]; then
-	cat /etc/motd.d/*.conf 2>/dev/null >> /run/coreos/motd || true
-fi
+for file in /etc/motd.d/*.conf; do
+	if [ -f "$file" ]; then
+		if [ -x "$file" ]; then
+			"$file" || true
+		else
+			cat "$file"
+		fi
+	fi
+done 2>/dev/null >> /run/coreos/motd


### PR DESCRIPTION
Currently we can have multiple files in /etc/motd.d/ and their content would be appended to MOTD. This change would check if the file is executable and, if so, append the ouput of the file to MOTD, not the content of the file. Non executable files would still get their content appended to MOTD. This also preserves alphabetical ordering.