### PR TITLE
coreos-install: Fix mounting filesystems through /dev/disk links

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -414,6 +414,7 @@ function write_to_disk() {
         echo "Failed to reread partitions on ${DEVICE}" >&2
     done
     [ -z "$try" ] || exit 1
+    udevadm settle
 }
 
 function install_from_file() {


### PR DESCRIPTION
After rereading the partition table, we weren't waiting for udev before trying to mount `ROOT` or `OEM`. That didn't matter if `${DEVICE}` was e.g. `/dev/sda`, since the partition device nodes would be created
by devtmpfs, but if `${DEVICE}` was a `/dev/disk` symlink, we'd try to access the partition symlink before udev got around to creating it and the mount would fail.