### PR TITLE
network: add units for Oracle OCI

### DIFF
--- a/systemd/network/yy-oracle-oci-bm.network
+++ b/systemd/network/yy-oracle-oci-bm.network
@@ -1,0 +1,14 @@
+[Match]
+KernelCommandLine=coreos.oem.id=oracle-oci
+# ixgbevf (in VMs) doesn't reset the NIC on MTU change
+# https://github.com/coreos/bugs/issues/2031
+Driver=!ixgbevf
+
+[Network]
+DHCP=yes
+
+[DHCP]
+UseMTU=false
+UseDomains=true
+# Root is on iSCSI
+CriticalConnection=true

--- a/systemd/network/yy-oracle-oci.network
+++ b/systemd/network/yy-oracle-oci.network
@@ -1,0 +1,14 @@
+[Match]
+KernelCommandLine=coreos.oem.id=oracle-oci
+# ixgbevf (in VMs) doesn't reset the NIC on MTU change
+# https://github.com/coreos/bugs/issues/2031
+Driver=ixgbevf
+
+[Network]
+DHCP=yes
+
+[DHCP]
+UseMTU=true
+UseDomains=true
+# Root is on iSCSI
+CriticalConnection=true


### PR DESCRIPTION
Set `CriticalConnection` on all interfaces, since one of them will be used for root-on-iSCSI and we don't know which.

Disable `UseMTU` on non-virtualized NICs to fix https://github.com/coreos/bugs/issues/2031.