### PR TITLE
tests: expand coreos-install test options

### DIFF
--- a/tests/install_test.go
+++ b/tests/install_test.go
@@ -17,9 +17,11 @@ package tests
 import (
 	"flag"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/coreos/init/tests/register"
+	"github.com/coreos/init/tests/util"
 
 	_ "github.com/coreos/init/tests/registry"
 )
@@ -36,9 +38,20 @@ func TestMain(m *testing.M) {
 }
 
 func TestCoreosInstall(t *testing.T) {
+	// download an image to speed up most tests
+	localImagePath := util.FetchLocalImage(t)
+	defer os.RemoveAll(localImagePath)
+
+	server := util.HTTPServer{
+		FileDir: localImagePath,
+	}
+	addr := server.Start(t)
+
 	for _, test := range register.Tests {
 		t.Run(test.Name, func(t *testing.T) {
 			test.BinaryPath = flagBinaryPath
+			test.LocalImagePath = filepath.Join(localImagePath, "coreos_production_image.bin.bz2")
+			test.LocalAddress = addr
 			test.Run(t)
 		})
 	}

--- a/tests/negative/disk_size.go
+++ b/tests/negative/disk_size.go
@@ -1,0 +1,59 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package negative
+
+import (
+	"testing"
+
+	"github.com/coreos/init/tests/register"
+	"github.com/coreos/init/tests/util"
+)
+
+var (
+	diskSize = "No space left on device"
+)
+
+func init() {
+	register.Register(register.Test{
+		Name:         "Disk Size too small - Local",
+		Func:         installShouldFail,
+		DiskSize:     2 * 1024 * 1024 * 1024,
+		UseLocalFile: true,
+		OutputRegexp: diskSize,
+	})
+	register.Register(register.Test{
+		Name:           "Disk Size too small - Remote",
+		Func:           installShouldFail,
+		DiskSize:       2 * 1024 * 1024 * 1024,
+		UseLocalServer: true,
+		OutputRegexp:   diskSize,
+	})
+}
+
+func installShouldFail(t *testing.T, test register.Test) {
+	diskFile, loopDevice := test.CreateDevice(t)
+	defer test.CleanupDisk(t, diskFile, loopDevice)
+
+	out, err := test.RunCoreOSInstallNegative(t, loopDevice)
+	if err == nil {
+		t.Fatalf("install passed when it shouldn't have")
+	}
+
+	if !util.RegexpContains(t, test.OutputRegexp, out) {
+		t.Fatalf("failed output validation: %s", out)
+	}
+
+	test.ValidatePartitionTableWiped(t, diskFile)
+}

--- a/tests/positive/general.go
+++ b/tests/positive/general.go
@@ -32,6 +32,7 @@ func init() {
 		IgnitionConfig: util.StringToPtr(`{
 			"ignition": {"version": "2.1.0"}
 		}`),
+		UseLocalServer: true,
 	})
 	register.Register(register.Test{
 		Name: "CloudConfig Test",
@@ -39,6 +40,7 @@ func init() {
 		CloudConfig: util.StringToPtr(`#cloud-config
 
 		hostname: "coreos1"`),
+		UseLocalServer: true,
 	})
 }
 

--- a/tests/positive/general.go
+++ b/tests/positive/general.go
@@ -42,6 +42,29 @@ func init() {
 		hostname: "coreos1"`),
 		UseLocalServer: true,
 	})
+	register.Register(register.Test{
+		Name:    "Alpha 1520.0",
+		Func:    baseTest,
+		Channel: util.StringToPtr("alpha"),
+		Version: util.StringToPtr("1520.0.0"),
+	})
+	register.Register(register.Test{
+		Name:    "Channel Only",
+		Func:    baseTest,
+		Channel: util.StringToPtr("beta"),
+	})
+	register.Register(register.Test{
+		Name:    "arm64-usr alpha 1367.5.0",
+		Func:    baseTest,
+		Channel: util.StringToPtr("alpha"),
+		Version: util.StringToPtr("1367.5.0"),
+		Board:   util.StringToPtr("arm64-usr"),
+	})
+	register.Register(register.Test{
+		Name:    "Version Only",
+		Func:    baseTest,
+		Version: util.StringToPtr("1409.7.0"),
+	})
 }
 
 func baseTest(t *testing.T, test register.Test) {

--- a/tests/register/register.go
+++ b/tests/register/register.go
@@ -41,6 +41,11 @@ type Test struct {
 	Board          *string
 	UseLocalFile   bool
 	UseLocalServer bool
+
+	// used in negative tests to allow them to
+	// provide a regexp to validate the output
+	// of coreos-install
+	OutputRegexp string
 }
 
 func (test Test) Run(t *testing.T) {
@@ -165,6 +170,14 @@ func (test Test) RunCoreOSInstall(t *testing.T, loopDevice string, opts ...strin
 	t.Logf("running: %s %s", test.BinaryPath, strings.Join(options, " "))
 
 	util.MustRun(t, test.BinaryPath, options...)
+}
+
+func (test Test) RunCoreOSInstallNegative(t *testing.T, loopDevice string, opts ...string) ([]byte, error) {
+	options := test.GetInstallOptions(t, loopDevice, opts...)
+
+	t.Logf("running: %s %s", test.BinaryPath, strings.Join(options, " "))
+
+	return exec.Command(test.BinaryPath, options...).CombinedOutput()
 }
 
 func (test Test) RemoveAll(t *testing.T, path string) {

--- a/tests/register/register.go
+++ b/tests/register/register.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -32,6 +33,14 @@ type Test struct {
 	DiskSize       int64
 	IgnitionConfig *string
 	CloudConfig    *string
+	LocalImagePath string
+	LocalAddress   string
+	Version        *string
+	BaseURL        *string
+	Channel        *string
+	Board          *string
+	UseLocalFile   bool
+	UseLocalServer bool
 }
 
 func (test Test) Run(t *testing.T) {
@@ -107,8 +116,35 @@ func (test Test) UnmountPartitions(t *testing.T, loopDevice string) {
 	util.MustRun(t, "umount", fmt.Sprintf("%sp9", loopDevice))
 }
 
-func (test Test) RunCoreOSInstall(t *testing.T, loopDevice string, opts ...string) {
+func (test Test) GetInstallOptions(t *testing.T, loopDevice string, opts ...string) []string {
 	opts = append(opts, "-d", loopDevice)
+
+	if test.UseLocalServer {
+		opts = append(opts, "-b", test.LocalAddress)
+	}
+
+	if test.UseLocalFile {
+		if test.LocalImagePath == "" {
+			t.Fatalf("test specifies using local file which doesn't exist")
+		}
+		opts = append(opts, "-f", test.LocalImagePath)
+	}
+
+	if test.Version != nil {
+		opts = append(opts, "-V", *test.Version)
+	}
+
+	if test.BaseURL != nil {
+		opts = append(opts, "-b", *test.BaseURL)
+	}
+
+	if test.Channel != nil {
+		opts = append(opts, "-C", *test.Channel)
+	}
+
+	if test.Board != nil {
+		opts = append(opts, "-B", *test.Board)
+	}
 
 	if test.IgnitionConfig != nil {
 		ignitionPath := test.WriteFile(t, "coreos-ignition-file", *test.IgnitionConfig)
@@ -120,7 +156,15 @@ func (test Test) RunCoreOSInstall(t *testing.T, loopDevice string, opts ...strin
 		opts = append(opts, "-c", cloudinitPath)
 	}
 
-	util.MustRun(t, test.BinaryPath, opts...)
+	return opts
+}
+
+func (test Test) RunCoreOSInstall(t *testing.T, loopDevice string, opts ...string) {
+	options := test.GetInstallOptions(t, loopDevice, opts...)
+
+	t.Logf("running: %s %s", test.BinaryPath, strings.Join(options, " "))
+
+	util.MustRun(t, test.BinaryPath, options...)
 }
 
 func (test Test) RemoveAll(t *testing.T, path string) {
@@ -166,7 +210,9 @@ func (test Test) ValidateIgnition(t *testing.T, rootDir, config string) {
 		t.Fatalf("reading grub.cfg: %v", err)
 	}
 
-	util.RegexpContains(t, "ignition grub.cfg info", "coreos.config.url=oem:///coreos-install.json", data)
+	if !util.RegexpContains(t, "coreos.config.url=oem:///coreos-install.json", data) {
+		t.Fatalf("grub.cfg doesn't contain a reference to coreos-install.json: %s", data)
+	}
 }
 
 func (test Test) ValidateCloudConfig(t *testing.T, rootDir, config string) {
@@ -183,10 +229,39 @@ func (test Test) ValidateCloudConfig(t *testing.T, rootDir, config string) {
 }
 
 func (test Test) ValidateOSRelease(t *testing.T, rootDir string) {
-	if _, err := os.Stat(filepath.Join(rootDir, "usr", "lib", "os-release")); os.IsNotExist(err) {
+	data, err := ioutil.ReadFile(filepath.Join(rootDir, "usr", "lib", "os-release"))
+	if os.IsNotExist(err) {
 		t.Fatalf("/usr/lib/os-release was not found")
 	} else if err != nil {
-		t.Fatalf("running stat on /usr/lib/os-release: %v", err)
+		t.Fatalf("reading /usr/lib/os-release: %v", err)
+	}
+
+	if test.Version != nil && *test.Version != util.RegexpSearch(t, "version", "VERSION_ID=(.*)", data) {
+		t.Fatalf("expected version differs: expected: %s, received: %s", *test.Version, data)
+	}
+
+	if test.Board != nil && *test.Board != util.RegexpSearch(t, "board", "COREOS_BOARD=\"(.*)\"", data) {
+		t.Fatalf("expected board differs: expected %s, received: %s", *test.Board, data)
+	}
+}
+
+func (test Test) ValidateChannel(t *testing.T, rootDir string) {
+	data, err := ioutil.ReadFile(filepath.Join(rootDir, "etc", "coreos", "update.conf"))
+	if err != nil {
+		t.Fatalf("reading /etc/coreos/update.conf: %v", err)
+	}
+
+	if *test.Channel != util.RegexpSearch(t, "channel", "GROUP=(.*)", data) {
+		t.Fatalf("expected channel differs: expected %s, received %s", *test.Channel, data)
+	}
+}
+
+func (test Test) ValidatePartitionTableWiped(t *testing.T, diskFile string) {
+	partitionTable := util.Run(t, "blkid", diskFile)
+
+	// after a wipe blkid will exit with the error "exit status 1" with no output
+	if partitionTable == nil {
+		t.Fatalf("partition table was not wiped")
 	}
 }
 
@@ -199,6 +274,10 @@ func (test Test) DefaultChecks(t *testing.T, rootDir string) {
 
 	if test.CloudConfig != nil {
 		test.ValidateCloudConfig(t, rootDir, *test.CloudConfig)
+	}
+
+	if test.Channel != nil {
+		test.ValidateChannel(t, rootDir)
 	}
 }
 

--- a/tests/registry/registry.go
+++ b/tests/registry/registry.go
@@ -15,5 +15,6 @@
 package registry
 
 import (
+	_ "github.com/coreos/init/tests/negative"
 	_ "github.com/coreos/init/tests/positive"
 )


### PR DESCRIPTION
Also adds support for local image file caching. The `UseLocalServer` flag can be used to pull from the local HTTP server.

------------

Adds flags to the Test object for the following options:

- Disk Size
     * Size of the disk the image is being installed onto. Defaults to 10Gb

- Board
- LocalImage
- Version
- BaseURL
- Channel
- UseLocalServer

------------

The following tests have switched to pulling from the local HTTP server:

- TestCoreosInstall/Ignition_Test
- TestCoreosInstall/CloudConfig_Test
- TestCoreosInstall/Disk_Size_too_small_-_Remote

------------

The following tests are added in this PR:

- TestCoreosInstall/Disk_Size_too_small_-_Local
- TestCoreosInstall/Disk_Size_too_small_-_Remote
- TestCoreosInstall/Alpha_1520.0
- TestCoreosInstall/Channel_Only
- TestCoreosInstall/arm64-usr_alpha_1367.5.0
- TestCoreosInstall/Version_Only