### PR TITLE
tests/coreos-install: add oem flag & tests

### DIFF
--- a/test
+++ b/test
@@ -36,6 +36,6 @@ echo "Checking govet..."
 go vet $PKG_VET
 
 echo "Running tests..."
-go test -timeout 9999s -cover $@ ${PKG} --race --test.v --coreos-install=${GOBIN}/coreos-install
+go test -timeout 9999s -cover $@ ${PKG} --race --test.v --parallel 5 --coreos-install=${GOBIN}/coreos-install
 
 echo "Success"

--- a/tests/coreos-install/positive/general.go
+++ b/tests/coreos-install/positive/general.go
@@ -65,6 +65,36 @@ func init() {
 		Func:    baseTest,
 		Version: util.StringToPtr("1409.7.0"),
 	})
+	register.Register(register.Test{
+		Name: "OEM - ami",
+		Func: baseTest,
+		OEM:  util.StringToPtr("ami"),
+	})
+	register.Register(register.Test{
+		Name: "OEM - cloudstack",
+		Func: baseTest,
+		OEM:  util.StringToPtr("cloudstack"),
+	})
+	register.Register(register.Test{
+		Name: "OEM - digitalocean",
+		Func: baseTest,
+		OEM:  util.StringToPtr("digitalocean"),
+	})
+	register.Register(register.Test{
+		Name: "OEM - packet",
+		Func: baseTest,
+		OEM:  util.StringToPtr("packet"),
+	})
+	register.Register(register.Test{
+		Name: "OEM - rackspace",
+		Func: baseTest,
+		OEM:  util.StringToPtr("rackspace"),
+	})
+	register.Register(register.Test{
+		Name: "OEM - vmware_raw",
+		Func: baseTest,
+		OEM:  util.StringToPtr("vmware_raw"),
+	})
 }
 
 func baseTest(t *testing.T, test register.Test) {

--- a/tests/coreos-install/register/register.go
+++ b/tests/coreos-install/register/register.go
@@ -26,6 +26,11 @@ import (
 	"github.com/coreos/init/tests/coreos-install/util"
 )
 
+var oemMap = map[string]string{
+	"vmware_raw": "vmware",
+	"ami":        "ec2",
+}
+
 type Test struct {
 	Name           string
 	Func           func(*testing.T, Test)
@@ -38,6 +43,7 @@ type Test struct {
 	Board          *string
 	UseLocalFile   bool
 	UseLocalServer bool
+	OEM            *string
 
 	// used in negative tests to allow them to
 	// provide a regexp to validate the output
@@ -155,6 +161,10 @@ func (test Test) GetInstallOptions(t *testing.T, loopDevice string, opts ...stri
 
 	if test.Board != nil {
 		opts = append(opts, "-B", *test.Board)
+	}
+
+	if test.OEM != nil {
+		opts = append(opts, "-o", *test.OEM)
 	}
 
 	if test.IgnitionConfig != nil {
@@ -284,6 +294,24 @@ func (test Test) ValidatePartitionTableWiped(t *testing.T, diskFile string) {
 	}
 }
 
+func (test Test) ValidateOEM(t *testing.T, rootDir string) {
+	data, err := ioutil.ReadFile(filepath.Join(rootDir, "usr", "share", "oem", "grub.cfg"))
+	if err != nil {
+		t.Fatalf("reading /usr/share/oem/grub.cfg: %v", err)
+	}
+
+	var expectedOEM string
+	if val, ok := oemMap[*test.OEM]; ok {
+		expectedOEM = val
+	} else {
+		expectedOEM = *test.OEM
+	}
+
+	if expectedOEM != util.RegexpSearch(t, "oem", "oem_id=\"(.*)\"", data) {
+		t.Fatalf("expected oem differs: expected %s, received %s", expectedOEM, data)
+	}
+}
+
 func (test Test) DefaultChecks(t *testing.T, rootDir string) {
 	test.ValidateOSRelease(t, rootDir)
 
@@ -297,6 +325,10 @@ func (test Test) DefaultChecks(t *testing.T, rootDir string) {
 
 	if test.Channel != nil {
 		test.ValidateChannel(t, rootDir)
+	}
+
+	if test.OEM != nil {
+		test.ValidateOEM(t, rootDir)
 	}
 }
 


### PR DESCRIPTION
Adds the OEM flag to the test object and the following new tests:

 - TestCoreosInstall/OEM_-_ami
 - TestCoreosInstall/OEM_-_cloudstack
 - TestCoreosInstall/OEM_-_digitalocean
 - TestCoreosInstall/OEM_-_packet
 - TestCoreosInstall/OEM_-_rackspace
 - TestCoreosInstall/OEM_-_vmware_raw
 - TestCoreosInstall/OEM_-_xen
