### PR TITLE
tests/coreos-install: add network units flag + test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ _trial_temp
 .idea/
 
 gopath/
+*.test

--- a/test
+++ b/test
@@ -35,7 +35,14 @@ fi
 echo "Checking govet..."
 go vet $PKG_VET
 
-echo "Running tests..."
-go test -timeout 9999s -cover $@ ${PKG} --race --test.v --parallel 5 --coreos-install=${GOBIN}/coreos-install
+if [ "${ACTION:-TEST}" != "COMPILE" ]; then
+	echo "Running tests..."
+	go test -timeout 9999s -cover $@ ${PKG} --race --test.v --parallel 5 --coreos-install=${GOBIN}/coreos-install
+else
+	echo "Compiling tests..."
+	for p in ${PKG}; do
+		go test -c $p
+	done
+fi
 
 echo "Success"

--- a/tests/coreos-install/install_test.go
+++ b/tests/coreos-install/install_test.go
@@ -53,6 +53,11 @@ func TestCoreosInstall(t *testing.T) {
 		LocalAddress:   addr,
 	}
 
+	networkUnit := util.CreateNetworkUnit(t)
+	if networkUnit != "" {
+		defer os.RemoveAll(networkUnit)
+	}
+
 	for _, test := range register.Tests {
 		t.Run(test.Name, func(t *testing.T) {
 			test.Ctx = ctx

--- a/tests/coreos-install/positive/general.go
+++ b/tests/coreos-install/positive/general.go
@@ -39,7 +39,7 @@ func init() {
 		Func: baseTest,
 		CloudConfig: util.StringToPtr(`#cloud-config
 
-		hostname: "coreos1"`),
+hostname: "coreos1"`),
 		UseLocalServer: true,
 	})
 	register.Register(register.Test{

--- a/tests/coreos-install/positive/general.go
+++ b/tests/coreos-install/positive/general.go
@@ -61,9 +61,8 @@ func init() {
 		Board:   util.StringToPtr("arm64-usr"),
 	})
 	register.Register(register.Test{
-		Name:    "Version Only",
-		Func:    baseTest,
-		Version: util.StringToPtr("1409.7.0"),
+		Name: "Version Only",
+		Func: pickVersion,
 	})
 	register.Register(register.Test{
 		Name: "OEM - ami",
@@ -95,6 +94,32 @@ func init() {
 		Func: baseTest,
 		OEM:  util.StringToPtr("vmware_raw"),
 	})
+}
+
+// used by tests which want to test versions without pinning
+// a specific channel as on Container Linux machines the
+// channel will default to the host machines channel.
+//
+// Will update the test.Version flag with the selected Version
+func pickVersion(t *testing.T, test register.Test) {
+	pinnedVersions := map[string]string{
+		"alpha":  "1535.0.0",
+		"beta":   "1520.3.0",
+		"stable": "1465.7.0",
+	}
+
+	channel, _, _, err := util.GetDefaultChannelBoardVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if version, ok := pinnedVersions[channel]; ok {
+		test.Version = util.StringToPtr(version)
+	} else {
+		t.Fatalf("unknown channel %s", channel)
+	}
+
+	baseTest(t, test)
 }
 
 func baseTest(t *testing.T, test register.Test) {

--- a/tests/coreos-install/positive/general.go
+++ b/tests/coreos-install/positive/general.go
@@ -94,6 +94,12 @@ func init() {
 		Func: baseTest,
 		OEM:  util.StringToPtr("vmware_raw"),
 	})
+	register.Register(register.Test{
+		Name:           "Network Units Test",
+		Func:           baseTest,
+		UseLocalServer: true,
+		NetworkUnits:   true,
+	})
 }
 
 // used by tests which want to test versions without pinning

--- a/tests/coreos-install/util/util.go
+++ b/tests/coreos-install/util/util.go
@@ -28,13 +28,21 @@ import (
 	"testing"
 )
 
-func RegexpSearch(t *testing.T, itemName, pattern string, data []byte) string {
+func TryRegexpSearch(name, pattern string, data []byte) (string, error) {
 	re := regexp.MustCompile(pattern)
 	match := re.FindSubmatch(data)
 	if len(match) < 2 {
-		t.Fatalf("couldn't find %s", itemName)
+		return "", fmt.Errorf("didn't find %s", name)
 	}
-	return string(match[1])
+	return string(match[1]), nil
+}
+
+func RegexpSearch(t *testing.T, itemName, pattern string, data []byte) string {
+	result, err := TryRegexpSearch(itemName, pattern, data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
 }
 
 func RegexpContains(t *testing.T, pattern string, data []byte) bool {
@@ -106,6 +114,43 @@ func FetchLocalImage(t *testing.T) string {
 	return tmpDir
 }
 
+// Used to get defaults for channel, board, & version, first checks if the
+// host machine is Container Linux and if so uses the data from the machine
+// otherwise defaults to stable, amd64-usr, & current respectively
+func GetDefaultChannelBoardVersion() (string, string, string, error) {
+	data, err := ioutil.ReadFile("/usr/lib/os-release")
+	if err != nil {
+		return "stable", "amd64-usr", "current", nil
+	}
+
+	os, err := TryRegexpSearch("id", "ID=['\"]?([A-Za-z0-9 \\._\\-]*)['\"]?", data)
+	if err != nil || os != "coreos" {
+		return "stable", "amd64-usr", "current", nil
+	}
+
+	version, err := TryRegexpSearch("version", "VERSION_ID=['\"]?([A-Za-z0-9 \\._\\-]*)['\"]?", data)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	board, err := TryRegexpSearch("board", "COREOS_BOARD=['\"]?([A-Za-z0-9 \\._\\-]*)['\"]?", data)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	data, err = ioutil.ReadFile("/etc/coreos/update.conf")
+	if err != nil {
+		return "", "", "", fmt.Errorf("reading /etc/coreos/update.conf: %v", err)
+	}
+
+	channel, err := TryRegexpSearch("channel", "GROUP=['\"]?([A-Za-z0-9 \\._\\-]*)['\"]?", data)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return channel, board, version, nil
+}
+
 func DownloadFile(tmpDir, name string) error {
 	file, err := os.Create(filepath.Join(tmpDir, name))
 	if err != nil {
@@ -113,7 +158,12 @@ func DownloadFile(tmpDir, name string) error {
 	}
 	defer file.Close()
 
-	resp, err := http.Get(fmt.Sprintf("https://stable.release.core-os.net/amd64-usr/current/%s", name))
+	channel, board, version, err := GetDefaultChannelBoardVersion()
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Get(fmt.Sprintf("https://%s.release.core-os.net/%s/%s/%s", channel, board, version, name))
 	if err != nil {
 		return fmt.Errorf("failed to download file: %v", err)
 	}


### PR DESCRIPTION
Updates the local HTTP server & file cache to attempt to detect
the version, board & channel of the host machine if it is
Container Linux before defaulting back to current, amd64-usr,
stable respectively. This mirrors the functionality present in
the coreos-install script.

---------

Adds the following flag onto the Test object:

- NetworkUnits

Adds the following tests:

- TestCoreosInstall/Network_Units_Test

---------

Also updates the test file to add the ability to compile the tests
via setting the variable `ACTION` to `COMPILE`, this is useful for
running the tests on a Container Linux machine, as you can
generate a compiled test file inside of a docker container with go
and then run them natively.