### PR TITLE
systemd: fsck EFI-SYSTEM and OEM; drop unnecessary OEM mount option

### DIFF
--- a/systemd/system/boot.mount
+++ b/systemd/system/boot.mount
@@ -1,10 +1,11 @@
 [Unit]
 Description=Boot partition
 DefaultDependencies=no
+Requires=systemd-fsck@dev-disk-by\x2dlabel-EFI\x2dSYSTEM.service
+After=systemd-fsck@dev-disk-by\x2dlabel-EFI\x2dSYSTEM.service
 ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 
 [Mount]
 What=/dev/disk/by-label/EFI-SYSTEM
 Where=/boot
-

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -4,6 +4,8 @@ Wants=addon-run@usr-share-oem.service addon-config@usr-share-oem.service
 Before=addon-run@usr-share-oem.service addon-config@usr-share-oem.service
 Conflicts=umount.target
 Before=local-fs.target umount.target ldconfig.service
+Requires=systemd-fsck@dev-disk-by\x2dlabel-OEM.service
+After=systemd-fsck@dev-disk-by\x2dlabel-OEM.service
 ConditionVirtualization=!container
 ConditionPathExists=!/usr/.noupdate
 

--- a/systemd/system/usr-share-oem.mount
+++ b/systemd/system/usr-share-oem.mount
@@ -10,5 +10,5 @@ ConditionPathExists=!/usr/.noupdate
 [Mount]
 What=/dev/disk/by-label/OEM
 Where=/usr/share/oem
-Options=nodev,commit=600
+Options=nodev
 Type=ext4


### PR DESCRIPTION
Addresses https://github.com/coreos/bugs/issues/2245.