### PR TITLE
configs/sshd_config: remove deprecated option

### DIFF
--- a/configs/sshd_config
+++ b/configs/sshd_config
@@ -1,5 +1,4 @@
 # Use most defaults for sshd configuration.
-UsePrivilegeSeparation sandbox
 Subsystem sftp internal-sftp
 ClientAliveInterval 180
 UseDNS no


### PR DESCRIPTION
Openssh 7.6 removes support for UsePrivilegeSeperation. Remove this from
our config to silence warnings about it.