### PR TITLE
coreos-install: increase wait_for_disk timeout

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -391,7 +391,7 @@ function is_modified() [[ -e "${WORKDIR}/disk_modified" ]]
 _disk_status=
 function wait_for_disk() {
     [ -n "${_disk_status}" ] ||
-    read -rt 300 _disk_status <> "${WORKDIR}/disk_modified"
+    read -rt 7200 _disk_status <> "${WORKDIR}/disk_modified"
 }
 
 function write_to_disk() {


### PR DESCRIPTION
`install_from_url` returns as soon as all image data has been accepted by the page cache (modulo the pipe buffer size) but `write_to_disk` doesn't return until after the page cache has been flushed to disk. For e.g. slow USB devices, the interval between the two can be longer than five minutes. Increase the `wait_for_disk` timeout to two hours, which should hopefully trigger only in pathological cases.