### PR TITLE
coreos-install: Cleanup usage message

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -44,21 +44,21 @@ for f in /usr/share/oem/oem-release /etc/oem-release; do
     fi
 done
 
-USAGE="Usage: $0 [-C channel] -d /dev/device
+USAGE="Usage: $0 -d <device> [options]
 Options:
     -d DEVICE   Install Container Linux to the given device.
-    -V VERSION  Version to install (e.g. current) [default: ${VERSION_ID}]
-    -B BOARD    Container Linux board to use [default: ${BOARD}]
-    -C CHANNEL  Release channel to use (e.g. beta) [default: ${CHANNEL_ID}]
-    -o OEM      OEM type to install (e.g. ami) [default: ${OEM_ID:-(none)}]
+    -V VERSION  Version to install (e.g. current) [default: ${VERSION_ID}].
+    -B BOARD    Container Linux board to use [default: ${BOARD}].
+    -C CHANNEL  Release channel to use (e.g. beta) [default: ${CHANNEL_ID}].
+    -o OEM      OEM type to install (e.g. ami) [default: ${OEM_ID:-(none)}].
     -c CLOUD    Insert a cloud-init config to be executed on boot.
     -i IGNITION Insert an Ignition config to be executed on boot.
-    -b BASEURL  URL to the image mirror (overrides BOARD)
-    -k KEYFILE  Override default GPG key for verifying image signature
-    -f IMAGE    Install unverified local image file to disk instead of fetching
+    -b BASEURL  URL to the image mirror (overrides BOARD).
+    -k KEYFILE  Override default GPG key for verifying image signature.
+    -f IMAGE    Install unverified local image file to disk instead of fetching.
     -n          Copy generated network units to the root partition.
     -v          Super verbose, for debugging.
-    -h          This ;-)
+    -h          This ;-).
 
 This tool installs CoreOS Container Linux on a block device. If you PXE booted
 Container Linux on a machine then use this tool to make a permanent install.
@@ -388,6 +388,7 @@ done
 # Device is required, must not be a partition, must be writable
 if [[ -z "${DEVICE}" ]]; then
     echo "$0: No target block device provided, -d is required." >&2
+    echo "$USAGE" >&2
     exit 1
 fi
 

--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -57,6 +57,7 @@ Options:
     -k KEYFILE  Override default GPG key for verifying image signature.
     -f IMAGE    Install unverified local image file to disk instead of fetching.
     -n          Copy generated network units to the root partition.
+    -y          Dry-run.  Run some checks and print option settings.
     -v          Super verbose, for debugging.
     -h          This ;-).
 
@@ -364,7 +365,7 @@ IMAGE_FILE=
 KEYFILE=
 VERSION_SUMMARY='CoreOS Container Linux'
 
-while getopts "V:B:C:d:o:c:i:t:b:k:f:nvh" OPTION
+while getopts "V:B:C:d:o:c:i:t:b:k:f:nyvh" OPTION
 do
     case $OPTION in
         V) VERSION_ID="$OPTARG"; VERSION_SPECIFIED=1 ;;
@@ -379,11 +380,26 @@ do
         k) KEYFILE="$OPTARG" ;;
         f) IMAGE_FILE="$OPTARG" ;;
         n) COPY_NET=1;;
+        y) DRY_RUN=1 ;;
         v) set -x ;;
         h) echo "$USAGE"; exit;;
         *) exit 1;;
     esac
 done
+
+function print_settings() {
+    echo "\
+Settings:
+    VERSION:  ${VERSION_ID}
+    BOARD:    ${BOARD}
+    CHANNEL:  ${CHANNEL_ID}
+    OEM:      ${OEM_ID:-(none)}
+    CLOUD:    ${CLOUDINIT:-(none)}
+    IGNITION: ${IGNITION:-(none)}
+    BASEURL:  ${BASE_URL:-(none)}
+    KEYFILE:  ${KEYFILE:-(none)}
+    IMAGE:    ${IMAGE_FILE:-(none)}"
+}
 
 # Device is required, must not be a partition, must be writable
 if [[ -z "${DEVICE}" ]]; then
@@ -423,6 +439,11 @@ if [[ -n "${IGNITION}" ]]; then
         echo "$0: Ignition config file (${IGNITION}) does not exist." >&2
         exit 1
     fi
+fi
+
+if [[ -n "${DRY_RUN}" ]]; then
+    print_settings
+    exit 0
 fi
 
 function is_modified() [[ -e "${WORKDIR}/disk_modified" ]]


### PR DESCRIPTION
Output the usage message after all the command line options are
processed so the user specified options will show as the 'default'
values.  This will allow the user to confirm the options are correct
before doing the install by running the script with the -h option.

Also, print the default value for all options, and, for consistency,
add a period to the end of some usage lines.
