### PR TITLE
coreos-install: write Ignition config to magic OEM path

### DIFF
--- a/bin/coreos-install
+++ b/bin/coreos-install
@@ -605,8 +605,7 @@ function write_ignition() if [[ -n "${IGNITION}" ]]; then
     trap 'umount "${WORKDIR}/oemfs"' RETURN
 
     echo "Installing Ignition config ${IGNITION}..."
-    cp "${IGNITION}" "${WORKDIR}/oemfs/coreos-install.json"
-    echo 'set linux_append="$linux_append coreos.config.url=oem:///coreos-install.json"' >> "${WORKDIR}/oemfs/grub.cfg"
+    cp "${IGNITION}" "${WORKDIR}/oemfs/config.ign"
 fi
 
 WORKDIR=$(mktemp --tmpdir -d coreos-install.XXXXXXXXXX)


### PR DESCRIPTION
Starting with Ignition 0.20.0, Container Linux will automatically use an Ignition config at /usr/share/oem/config.ign. Put the user-specified config there so we don't have to modify the kernel command line.

Fixes https://github.com/coreos/bugs/issues/2291.