### PR TITLE
udev: add support for AWS EBS NVMe friendly names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ install:
 	install -m 755 systemd/system-generators/* \
 		$(DESTDIR)/usr/lib/systemd/system-generators
 	install -m 644 udev/rules.d/* $(DESTDIR)/lib/udev/rules.d
+	install -m 755 udev/bin/* $(DESTDIR)/lib/udev
 	install -m 644 configs/editor.sh $(DESTDIR)/etc/env.d/99editor
 	install -m 644 configs/logrotate.conf $(DESTDIR)/usr/share/logrotate/
 	install -m 600 configs/sshd_config $(DESTDIR)/usr/share/ssh/

--- a/udev/bin/cloud_aws_ebs_nvme_id
+++ b/udev/bin/cloud_aws_ebs_nvme_id
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2018 The CoreOS Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+usage() {
+    echo "Usage: $0 [-d|-p|-h] <device>" 1>&2
+}
+
+# Get partition ID from device name, e.g. '/dev/nvme0n1p2' -> '1'
+namespace_id() {
+    check_udev_aws
+    NSID=$(echo -n "$1" | cut -f 3 -d 'n' | cut -f 1 -d 'p')
+    echo "_NS_ID=${NSID}"
+}
+
+# Get device name from raw metadata,
+# see https://github.com/coreos/bugs/issues/2399.
+devname() {
+    check_udev_aws
+    RAWVOL=$(nvme id-ctrl --raw-binary "$1" | cut -c3073-3104 | tr -s ' ' | sed 's/ $//g')
+    VOL="${RAWVOL#/dev/}"
+    if [[ -n "$VOL" ]]; then
+        echo "${VOL}"
+    else
+        exit 1
+    fi
+}
+
+# Ensure this is run with proper environment populated by udev,
+# and acting on an AWS EBS device.
+check_udev_aws() {
+    if [ "${ID_MODEL}" != "Amazon Elastic Block Store" ]; then
+        echo 'Stopping due to non-matching ID_MODEL env variable'
+        exit 1
+    fi
+}
+
+while getopts "hd:n:" o; do
+    case "${o}" in
+        d)
+            devname "${OPTARG}"
+            exit 0
+            ;;
+        n)
+            namespace_id "${OPTARG}"
+            exit 0
+            ;;
+        h)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done

--- a/udev/rules.d/90-cloud-storage.rules
+++ b/udev/rules.d/90-cloud-storage.rules
@@ -9,6 +9,16 @@ KERNEL=="sd*|vd*", ENV{ID_VENDOR}=="Google", ENV{ID_MODEL}=="PersistentDisk", EN
 KERNEL=="sd*|vd*", ENV{ID_VENDOR}=="Google", ENV{ID_MODEL}=="EphemeralDisk", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="disk", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}"
 KERNEL=="sd*|vd*", ENV{ID_VENDOR}=="Google", ENV{ID_MODEL}=="EphemeralDisk", ENV{ID_SERIAL_SHORT}=="?*", ENV{DEVTYPE}=="partition", SYMLINK+="disk/by-id/google-$env{ID_SERIAL_SHORT}-part%n"
 
+## AWS EBS NVMe names
+## https://github.com/coreos/bugs/issues/2399
+# NVMe devices
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-%n", OPTIONS+="string_escape=replace"
+KERNEL=="nvme[0-9]*n[0-9]*", ENV{DEVTYPE}=="disk", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", PROGRAM="cloud_aws_ebs_nvme_id -d /dev/%k", SYMLINK+="%c"
+# NVMe partitions
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", IMPORT{program}="cloud_aws_ebs_nvme_id -n /dev/%k"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", ENV{_NS_ID}=="?*", SYMLINK+="disk/by-id/nvme-$attr{model}_$attr{serial}-ns-$env{_NS_ID}-part%n", OPTIONS+="string_escape=replace"
+KERNEL=="nvme[0-9]*n[0-9]*p[0-9]*", ENV{DEVTYPE}=="partition", ATTRS{model}=="Amazon Elastic Block Store", ATTRS{serial}=="?*", ENV{_NS_ID}=="?*", PROGRAM="cloud_aws_ebs_nvme_id -d /dev/%k", SYMLINK+="%c%n"
+
 # TODO: Anyone else support friendly names?
 
 LABEL="cloud_storage_end"


### PR DESCRIPTION
Ref: https://github.com/coreos/bugs/issues/2399

Note: while this is AWS-specific, the payload is so small and the lack of updates for OEM partition scares me, so I'm proposing to add it here instead of a new OEM-specific ebuild.